### PR TITLE
Fix license file for PEP 621

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,8 +14,7 @@ classifiers = [
     "Programming Language :: Python :: 3",
     "Operating System :: OS Independent",
 ]
-license = "BSD-3-Clause"
-license-files = ["LICENCSE"]
+license = { text = "BSD-3-Clause" }
 requires-python = ">=3.10"
 dependencies = [
     "torch>=2.7.0",
@@ -64,3 +63,7 @@ known-third-party = ["torch"]
 required-imports = ["from __future__ import annotations"]
 force-single-line = true  # better merge conflicts
 force-sort-within-sections = true
+
+[tool.setuptools]
+license-files = ["LICENSE"]
+


### PR DESCRIPTION
While trying to build helion on my setup noticed three problems

1) LICENSE file is misspent
2) `license-files` is no longer supported under `[project]` with PEP621 needs to move under setuptools
3) license now needs to be specified text or file