### PR TITLE
Use search-strategy: all for all site packages in pyre config

### DIFF
--- a/.pyre_configuration
+++ b/.pyre_configuration
@@ -10,7 +10,7 @@
       "source": "examples"
     }
   ],
-  "optional_search_path": ["../pytorch"],
+  "optional_search_path": ["../pytorch", "../pytorch-hg"],
   "python_version": "3.10",
   "exclude": [".*third_party.*"],
   "strict": true

--- a/.pyre_configuration
+++ b/.pyre_configuration
@@ -10,6 +10,7 @@
       "source": "examples"
     }
   ],
+  "optional_search_path": ["../pytorch"],
   "python_version": "3.10",
   "exclude": [".*third_party.*"],
   "strict": true

--- a/.pyre_configuration
+++ b/.pyre_configuration
@@ -1,5 +1,5 @@
 {
-  "site_package_search_strategy": "pep561",
+  "site_package_search_strategy": "all",
   "source_directories": [
     {
       "import_root": ".",
@@ -11,11 +11,6 @@
     }
   ],
   "python_version": "3.10",
-  "search_path": [
-      {"site-package": "torch"},
-      {"site-package": "sympy"},
-      {"site-package": "triton"}
-  ],
   "exclude": [".*third_party.*"],
   "strict": true
 }


### PR DESCRIPTION
This PR attempts to make Pyre capable of checking using either installed `torch` from site packages, or if it is available a `torch` coming from a repository at `../pytorch`, relative to the current `helion` repository.

-----------

The first diff improves our options for making a local pytorch repo work, because it eliminates the rigid assumption that we'll find `torch` in the site-packages directory (otherwise, Pyre will crash complaining about an invalid search path entry).

It's also generally simpler, and eliminates other potential consequences of trying to enumerate the site pachage entries; this is the go-to mode I would generally use for Pyre.

Tested by setting up a virtualenv, making sure `pyre check` works on trunk, and seeing that I get a clean result after this config change.

----------

The second diff uses an "optional_search_path" to specify that `../pytorch` should be used as a search path, but only if it exists. I verified that:
- if there is no `../pytorch`, this will run as before
- if there *is* a `../pytorch`, it winds up as a search root, and *precedes* site-packages

Note that there's a tradeoff here: the fact that `../pytorch` gets precedence this means if there is a `../pytorch` directory but we are not intending to use it in the current development environment, we're still going to pick it up. That could lead to confusion if it's mismatched against the current conda env, but I don't really see a way around it.