### PR TITLE
Add HELION_LOGS

### DIFF
--- a/helion/__init__.py
+++ b/helion/__init__.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from . import _logging
 from . import exc
 from . import language
 from . import runtime
@@ -21,3 +22,5 @@ __all__ = [
     "runtime",
     "set_default_settings",
 ]
+
+_logging.init_logs()

--- a/helion/_logging/__init__.py
+++ b/helion/_logging/__init__.py
@@ -1,0 +1,4 @@
+from __future__ import annotations
+
+from ._internal import LazyString as LazyString
+from ._internal import init_logs as init_logs

--- a/helion/_logging/_internal.py
+++ b/helion/_logging/_internal.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from dataclasses import field
+import logging
+import os
+from typing import Callable
+from typing import ParamSpec
+
+LOG_ENV_VAR = "HELION_LOGS"
+
+"""
+Usage:
+
+HELION_LOGS=+helion.runtime.kernel python test.py
+
+will run test.py with helion.runtime.kernel logs enabled at logging.DEBUG level
+"""
+
+
+@dataclass
+class LogRegistery:
+    """
+    This registery holds mappings for logging
+    """
+    # alias -> list of logs
+    alias_map: dict[str, list[str]] = field(default_factory=dict)
+
+    # log name -> log level
+    log_levels: dict[str, int] = field(default_factory=dict)
+
+
+_LOG_REGISTERY = LogRegistery()
+
+
+def parse_log_value(value: str) -> None:
+    """
+    Given a string like "foo.bar,+baz.fizz" this function parses this string and converts
+    it to mapping of {"foo.bar": logging.INFO, "baz.fizz": logging.DEBUG}
+    and updates the registery with this mapping
+    """
+    entries = [e.strip() for e in value.split(",") if e.strip()]
+    for entry in entries:
+        log_level = logging.DEBUG if entry.startswith("+") else logging.INFO
+        alias = entry.lstrip("+")
+
+        if alias in _LOG_REGISTERY.alias_map:
+            for log in _LOG_REGISTERY.alias_map[alias]:
+                _LOG_REGISTERY.log_levels[log] = log_level
+        else:
+            _LOG_REGISTERY.log_levels[alias] = log_level
+
+
+def init_logs_from_string(value: str) -> None:
+    """
+    Installs basic logging based on the input value
+    """
+    parse_log_value(value)
+
+    for logger_name, level in _LOG_REGISTERY.log_levels.items():
+        logger = logging.getLogger(logger_name)
+        logger.setLevel(level)
+
+        handler = logging.StreamHandler()
+        handler.setLevel(level)
+        handler.setFormatter(
+            logging.Formatter(
+                fmt=f"%(asctime)s [{logger_name}] %(levelname)s: %(message)s",
+                datefmt="%Y-%m-%d %H:%M:%S",
+            )
+        )
+
+        logger.addHandler(handler)
+        logger.propagate = False
+
+
+def init_logs() -> None:
+    init_logs_from_string(os.environ.get(LOG_ENV_VAR, ""))
+
+
+P = ParamSpec("P")
+
+
+class LazyString:
+    def __init__(
+        self, func: Callable[P, str], *args: P.args, **kwargs: P.kwargs
+    ) -> None:
+        self.func: Callable[P, str] = func
+        self.args: tuple[object, ...] = args
+        self.kwargs: object = kwargs
+
+    def __str__(self) -> str:
+        return self.func(*self.args, **self.kwargs)

--- a/test/test_logging.py
+++ b/test/test_logging.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from expecttest import TestCase
+import torch
+
+import helion
+from helion._testing import DEVICE
+import helion.language as hl
+
+
+class TestLogging(TestCase):
+    def test_log_set(self):
+        import logging
+
+        from helion._logging._internal import init_logs_from_string
+
+        init_logs_from_string("foo.bar,+fuzz.baz")
+        self.assertTrue(
+            helion._logging._internal._LOG_REGISTERY.log_levels["foo.bar"], logging.INFO
+        )
+        self.assertTrue(
+            helion._logging._internal._LOG_REGISTERY.log_levels["fuzz.baz"],
+            logging.DEBUG,
+        )
+
+    def test_kernel_log(self):
+        @helion.kernel(
+            config=helion.Config(
+                block_sizes=[[1]], num_warps=16, num_stages=8, indexing="pointer"
+            )
+        )
+        def add(x, y):
+            x, y = torch.broadcast_tensors(x, y)
+            out = torch.empty_like(x)
+            for tile in hl.tile(out.size()):
+                out[tile] = x[tile] + y[tile]
+            return out
+
+        x = torch.randn(4, device=DEVICE)
+
+        with self.assertLogs("helion.runtime.kernel", level="DEBUG") as cm:
+            add(x, x)
+        self.assertTrue(
+            any("INFO:helion.runtime.kernel:Output code:" in msg for msg in cm.output)
+        )
+        self.assertTrue(
+            any("DEBUG:helion.runtime.kernel:Debug string:" in msg for msg in cm.output)
+        )


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #28
* __->__ #26

Usage:
```
HELION_LOGS=+helion.runtime.kernel python test.py
```
will run test.py with helion.runtime.kernel logs enabled at logging.DEBUG level

