### PR TITLE
Add hl.register_block_size and explicit tile sizes

### DIFF
--- a/helion/_compiler/host_function.py
+++ b/helion/_compiler/host_function.py
@@ -192,6 +192,10 @@ class HostFunction:
             return self.sympy_expr(expr._sympy_())
         if isinstance(expr, sympy.Expr):
             return self.sympy_expr(expr)
+        if isinstance(expr, list):
+            return "[" + ", ".join(self.literal_expr(x) for x in expr) + "]"
+        if isinstance(expr, tuple):
+            return "(" + ", ".join(self.literal_expr(x) for x in expr) + ", )"
         return repr(expr)
 
     def debug_str(self) -> str:

--- a/helion/_compiler/tile_index_proxy.py
+++ b/helion/_compiler/tile_index_proxy.py
@@ -60,6 +60,8 @@ class TileIndexProxy(torch.Tensor):
             and (index_calls := getattr(tls, "index_calls", None)) is not None
         ):
             index_calls.count += 1
+        if func is torch.Tensor.__format__:
+            return repr(args[0])
         raise exc.IncorrectTileUsage(func)
 
     @staticmethod

--- a/helion/_compiler/variable_origin.py
+++ b/helion/_compiler/variable_origin.py
@@ -226,9 +226,7 @@ class BlockSizeOrigin(Origin):
     def host_str(self) -> str:
         from .device_function import DeviceFunction
 
-        host_str = DeviceFunction.current().tile_strategy.block_size_var(
-            self.block_size_idx
-        )
+        host_str = DeviceFunction.current().block_size_var(self.block_size_idx)
         assert host_str is not None
         return host_str
 

--- a/helion/autotuner/config_spec.py
+++ b/helion/autotuner/config_spec.py
@@ -140,7 +140,7 @@ class ConfigSpec:
             expected = len(block_spec)
             if idx >= len(block_sizes):
                 raise InvalidConfig(
-                    f"Not enough block sizes, expected {expected}, got {len(block_sizes)}"
+                    f"Not enough block sizes, expected {sum(map(len, self.block_size_specs))}, got {len(block_sizes)}"
                 )
             val = block_sizes[idx]
             if (
@@ -266,6 +266,13 @@ class BlockSizeSpec:
         self.allow_l2_grouping = allow_l2_grouping
         self.min_sizes: list[int] = [1 for _ in size_hints]
         self.max_sizes: list[int] = [next_power_of_2(s) for s in size_hints]
+
+    def __repr__(self) -> str:
+        fields = [repr(self.size_hints)]
+        for name in ("allow_flattened", "allow_reorder", "allow_l2_grouping"):
+            if value := getattr(self, name):
+                fields.append(f"{name}={value}")
+        return f"BlockSizeSpec({', '.join(fields)})"
 
     def update_min(self, i: int, min_value: int) -> None:
         self.min_sizes[i] = max(

--- a/helion/exc.py
+++ b/helion/exc.py
@@ -61,6 +61,14 @@ class LoopFunctionNotInFor(BaseError):
     message = "{0} must be called from a for loop, e.g. `for ... in {0}(...):"
 
 
+class InvalidTileUsage(BaseError):
+    message = "{0}"
+
+
+class NestedDeviceLoopsConflict(BaseError):
+    message = "Nested device loops must have distinct block sizes."
+
+
 class DeviceLoopElseBlock(BaseError):
     message = "for...else block is not allowed in a {0} device loop."
 

--- a/helion/language/__init__.py
+++ b/helion/language/__init__.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from .constexpr import ConstExpr as constexpr  # noqa: F401
 from .creation_ops import full as full
 from .creation_ops import zeros as zeros
+from .loops import register_block_size as register_block_size
 from .loops import tile as tile
 from .memory_ops import load as load
 from .memory_ops import store as store

--- a/helion/language/creation_ops.py
+++ b/helion/language/creation_ops.py
@@ -18,7 +18,7 @@ if TYPE_CHECKING:
 __all__ = ["full", "zeros"]
 
 
-def zeros(shape: list[int], dtype: torch.dtype = torch.float32) -> torch.Tensor:
+def zeros(shape: list[object], dtype: torch.dtype = torch.float32) -> torch.Tensor:
     """
     Return a device-tensor filled with zeros
 
@@ -31,7 +31,7 @@ def zeros(shape: list[int], dtype: torch.dtype = torch.float32) -> torch.Tensor:
 
 @_decorators.api(tiles_as_sizes=True)
 def full(
-    shape: list[int], value: float, dtype: torch.dtype = torch.float32
+    shape: list[object], value: float, dtype: torch.dtype = torch.float32
 ) -> torch.Tensor:
     """
     Create a device-tensor filled with a specified value.

--- a/helion/language/loops.py
+++ b/helion/language/loops.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import ast
 from typing import TYPE_CHECKING
-from typing import Protocol
+from typing import Iterator
 from typing import overload
 
 import torch
@@ -11,6 +11,7 @@ from .. import exc
 from .._compiler.ast_extension import ExtendedAST
 from .._compiler.ast_extension import LoopType
 from .._compiler.ast_extension import expr_from_string
+from .._compiler.tile_index_proxy import TileIndexProxy
 from .._compiler.type_propagation import IterType
 from .._compiler.type_propagation import Origin
 from .._compiler.type_propagation import SequenceType
@@ -27,28 +28,32 @@ if TYPE_CHECKING:
     # hl.tile doesn't actually return a tensor, but we say it does so user code can typecheck cleanly
     TileOutput = torch.Tensor
 
-__all__ = ["TileIndexProtocol", "tile"]
-
-
-class TileIndexProtocol(Protocol):
-    """
-    Opaque type for tile() indices.  Should only be used to index tensors using the
-    `tensor[tile]` or `tensor[tile0, tile1]` operator.
-    """
+__all__ = ["register_block_size", "tile"]
 
 
 @overload
-@_decorators.api(is_device_loop=True, is_device_only=False, cache_type=True)
-def tile(sizes: int) -> TileOutput: ...
+@_decorators.api(
+    is_device_loop=True, is_device_only=False, cache_type=True, tiles_as_sizes=True
+)
+def tile(sizes: int, block_size: TileOutput | None = None) -> Iterator[TileOutput]: ...
 
 
 @overload
-@_decorators.api(is_device_loop=True, is_device_only=False, cache_type=True)
-def tile(sizes: Sequence[int]) -> Sequence[TileOutput]: ...
+@_decorators.api(
+    is_device_loop=True, is_device_only=False, cache_type=True, tiles_as_sizes=True
+)
+def tile(
+    sizes: Sequence[int], block_size: Sequence[TileOutput] | None = None
+) -> Iterator[Sequence[TileOutput]]: ...
 
 
-@_decorators.api(is_device_loop=True, is_device_only=False, cache_type=True)
-def tile(sizes: int | Sequence[int]) -> TileOutput | Sequence[TileOutput]:
+@_decorators.api(
+    is_device_loop=True, is_device_only=False, cache_type=True, tiles_as_sizes=True
+)
+def tile(
+    sizes: int | Sequence[int],
+    block_size: TileOutput | Sequence[TileOutput] | None = None,
+) -> Iterator[TileOutput] | Iterator[Sequence[TileOutput]]:
     """
     Break up an iteration space defined by a size or sequence of sizes into tiles.
     The generated tiles can flatten the iteration space into the product of the sizes,
@@ -77,7 +82,64 @@ def tile(sizes: int | Sequence[int]) -> TileOutput | Sequence[TileOutput]:
 
 
 @_decorators.type_propagation(tile)
-def _(sizes: TypeInfo, *, origin: Origin) -> TypeInfo:
+def _(
+    sizes: TypeInfo, block_size: TypeInfo | None = None, *, origin: Origin
+) -> TypeInfo:
+    parent = ExtendedAST.current()[-2]
+    if not isinstance(parent, ast.For):
+        raise exc.LoopFunctionNotInFor("tile")
+    if (
+        block_size is None
+        or block_size.is_literal()
+        and block_size.as_literal() is None
+    ):
+        result = _register_block_size_types(sizes, origin)
+    else:
+        try:
+            proxy_sizes = sizes.proxy()
+            proxy_block_size = TileIndexProxy.tiles_to_sizes(block_size.proxy())
+        except NotImplementedError:
+            raise exc.IncorrectTileUsage(
+                f"expected int or list[int], got {sizes!s} and {block_size!s}"
+            ) from None
+        if isinstance(proxy_sizes, (list, tuple)):
+            if not isinstance(proxy_block_size, (list, tuple)) or len(
+                proxy_sizes
+            ) != len(proxy_block_size):
+                raise exc.IncorrectTileUsage(
+                    f"expected dims for sizes and block_sizes to match, got {sizes!s} and {block_size!s}"
+                )
+            unpack = False
+        else:
+            if not isinstance(proxy_block_size, int | torch.SymInt):
+                raise exc.IncorrectTileUsage(
+                    f"expected type for sizes and block_sizes to match, got {sizes!s} and {block_size!s}"
+                )
+            proxy_sizes = [proxy_sizes]
+            proxy_block_size = [proxy_block_size]
+            unpack = True
+        results = []
+        for size, bs in zip(proxy_sizes, proxy_block_size, strict=True):
+            if bs is None:
+                results.append(TileIndexType.allocate([size], origin)[0])
+            elif isinstance(bs, int):
+                results.append(TileIndexType.allocate_fixed(size, bs, origin))
+            elif isinstance(bs, torch.SymInt):
+                from helion._compiler.tile_strategy import TileStrategy
+
+                index = TileStrategy.get_block_index(bs)
+                if index is None:
+                    results.append(TileIndexType.allocate_fixed(size, bs, origin))
+                else:
+                    results.append(TileIndexType(origin=origin, block_size_idx=index))
+        if unpack:
+            (result,) = results
+        else:
+            result = SequenceType(origin, results)
+    return IterType(origin, result)
+
+
+def _register_block_size_types(sizes: TypeInfo, origin: Origin) -> TypeInfo:
     try:
         proxy_sizes = sizes.proxy()
         if not (
@@ -87,20 +149,31 @@ def _(sizes: TypeInfo, *, origin: Origin) -> TypeInfo:
         ):
             raise NotImplementedError
     except NotImplementedError:
-        return UnknownType(
-            origin,
-            f"tile() expected int or list[int], got {sizes!s}",
-            chained_from=sizes,
-        )
-
-    parent = ExtendedAST.current()[-2]
-    if not isinstance(parent, ast.For):
-        raise exc.LoopFunctionNotInFor("tile")
+        raise exc.TypePropagationError(
+            UnknownType(
+                origin,
+                f"tile() expected int or list[int], got {sizes!s}",
+                chained_from=sizes,
+            )
+        ) from None
     if isinstance(proxy_sizes, (int, torch.SymInt)):
-        result = TileIndexType.allocate([proxy_sizes], origin)[0]
-    else:
-        result = SequenceType(origin, TileIndexType.allocate(proxy_sizes, origin))
-    return IterType(origin, result)
+        return TileIndexType.allocate([proxy_sizes], origin)[0]
+    return SequenceType(
+        origin=origin,
+        # pyre-fixme[6]
+        element_types=TileIndexType.allocate(proxy_sizes, origin),
+    )
+
+
+def _get_block_indices(type_info: TypeInfo) -> list[int]:
+    def visit(n: TypeInfo) -> TypeInfo:
+        if isinstance(n, TileIndexType):
+            result.append(n.block_size_idx)
+        return n
+
+    result: list[int] = []
+    type_info.tree_map(visit)
+    return result
 
 
 @_decorators.codegen(tile)
@@ -116,9 +189,38 @@ def _(state: CodegenState) -> ast.AST:
         tile_indices = [type_info.inner]
     assert all(isinstance(t, TileIndexType) for t in tile_indices)
     if loop_type == LoopType.GRID:
-        # TODO(jansel): implement 2D tiling, swizzling, etc
-        state.tile_strategy.codegen_grid(
-            state, [t.block_size_idx for t in tile_indices]
-        )
+        block_indices = [t.block_size_idx for t in tile_indices]
+        state.tile_strategy.codegen_grid(state, block_indices)
         return expr_from_string("None")
     raise AssertionError(f"Expected loop type: {loop_type}")
+
+
+@overload
+@_decorators.api(is_device_only=False, cache_type=True, tiles_as_sizes=True)
+def register_block_size(size: int) -> TileOutput: ...
+
+
+@overload
+@_decorators.api(is_device_only=False, cache_type=True, tiles_as_sizes=True)
+def register_block_size(size: Sequence[int]) -> Sequence[TileOutput]: ...
+
+
+@_decorators.api(is_device_only=False, cache_type=True, tiles_as_sizes=True)
+def register_block_size(size: int | Sequence[int]) -> TileOutput | Sequence[TileOutput]:
+    """
+    Explicitly register a block size that should be autotuned and can
+    be used for allocations and inside hl.tile().
+
+    This is useful if you have two loops where you want them to share
+    a block size, or if you need to allocate a kernel tensor before the
+    hl.tile() loop.
+
+    :param size:
+    :return:
+    """
+    raise exc.NotInsideKernel
+
+
+@_decorators.type_propagation(register_block_size)
+def _(sizes: TypeInfo, *, origin: Origin) -> TypeInfo:
+    return _register_block_size_types(sizes, origin)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,10 +49,10 @@ select = [
     "TD004", "TRY002", "TRY203", "TRY401", "UP", "W", "YTT",
 ]
 ignore = [
-    "C409", "C419", "COM812", "E501", "ERA001", "FURB189", "G004", "PERF203", "PT009",
-    "SIM102", "SIM108", "SIM115", "UP035", "UP038",
+    "C409", "C419", "COM812", "E501", "ERA001", "FURB189", "G004", "PERF203",
+    "PERF401", "PT009", "SIM102", "SIM108", "SIM115", "UP035", "UP038",
 ]
-extend-safe-fixes = ["TC", "UP045", "RUF013"]
+extend-safe-fixes = ["TC", "UP045", "RUF013", "RSE102"]
 preview = true
 exclude = ["test/data/*"]
 

--- a/test/test_reductions.py
+++ b/test/test_reductions.py
@@ -260,8 +260,9 @@ def root_graph_0():
     store = helion_language_memory_ops_store(out, [block_size_0], mean);  out = block_size_0 = mean = store = None
     return None
 
-def reduction_loop_1(x: "f32[s77, s27]"):
+def reduction_loop_1():
     # File: .../test_reductions.py:53 in reduce_kernel, code: out[tile_n] = fn(x[tile_n, :], dim=-1)
+    x: "f32[s77, s27]" = helion_language__tracing_ops__host_tensor('x')
     block_size_0: "Sym(u0)" = helion_language__tracing_ops__get_symnode('block_size_0')
     load: "f32[u0, u1]" = helion_language_memory_ops_load(x, [block_size_0, slice(None, None, None)]);  x = block_size_0 = None
     mean_extra: "f32[u0]" = helion_language__tracing_ops__inductor_lowering_extra([load]);  load = None
@@ -269,9 +270,8 @@ def reduction_loop_1(x: "f32[s77, s27]"):
 
 def root_graph_2():
     # File: .../test_reductions.py:53 in reduce_kernel, code: out[tile_n] = fn(x[tile_n, :], dim=-1)
-    x: "f32[s77, s27]" = helion_language__tracing_ops__host_tensor('x')
     block_size_0: "Sym(u0)" = helion_language__tracing_ops__get_symnode('block_size_0')
-    _for_loop = helion_language__tracing_ops__for_loop(1, [x]);  x = None
+    _for_loop = helion_language__tracing_ops__for_loop(1, [])
     getitem: "f32[u0]" = _for_loop[0];  _for_loop = None
     mean: "f32[u0]" = torch.ops.aten.mean.dim(None, [-1], _extra_args = [getitem]);  getitem = None
     out: "f32[s77]" = helion_language__tracing_ops__host_tensor('out')


### PR DESCRIPTION
This change makes the two pass softmax @drisspg was trying to implement possible, with some new syntax for pre-registering block sizes:
```python
@helion.kernel(config={"block_sizes": [1, 128]})
def softmax_two_pass(x: torch.Tensor) -> torch.Tensor:
    m, n = x.size()
    out = torch.empty_like(x)
    block_size_m = hl.register_block_size(m)
    block_size_n = hl.register_block_size(n)
    for tile_m in hl.tile(m, block_size=block_size_m):
        mi = hl.full([tile_m, 1], float("-inf"), dtype=torch.float32)
        di = hl.zeros([tile_m, block_size_n], dtype=torch.float32)
        for tile_n in hl.tile(n, block_size=block_size_n):
            values = x[tile_m, tile_n]
            local_amax = torch.amax(values, dim=1, keepdim=True)
            mi_next = torch.maximum(mi, local_amax)
            di = di * torch.exp(mi - mi_next) + torch.exp(values - mi_next)
            mi = mi_next
        for tile_n in hl.tile(n, block_size=block_size_n):
            values = x[tile_m, tile_n]
            out[tile_m, tile_n] = torch.exp(values - mi) / di
    return out
```
The part that was hard before was referencing `block_size_n` before the `tile_n` loop.


I also considered something like:
```py
di = hl.zeros([tile_m, hl.auto()], dtype=torch.float32)
```
Where the `hl.auto()` would be a placeholder value that we infer automatically during type propagation, though I think this version is clearer.