### PR TITLE
Update lint github workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,55 @@
+name: Lint
+
+on:
+  push:
+    branches:
+      - main
+      # Include any branch created via ghstack
+      - gh/**
+  pull_request:
+    branches:
+      - main
+      - gh/*
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash -l {0}
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+
+      - name: Set up Miniconda
+        uses: conda-incubator/setup-miniconda@v3
+        with:
+          activate-environment: torch27
+          python-version: 3.12
+          channels: defaults,pytorch,conda-forge
+
+      - name: Cache dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.conda/pkgs
+            ~/.cache/pip
+            ~/miniconda/envs/torch27
+          key: ${{ runner.os }}-deps-${{ hashFiles('.github/workflows/lint.yml') }}
+          restore-keys: |
+            ${{ runner.os }}-deps-
+
+      - name: Install CUDA
+        run: |
+          conda install nvidia/label/cuda-12.8.1::cuda-toolkit
+
+      - name: Install PyTorch
+        run: |
+          pip3 install torch --index-url https://download.pytorch.org/whl/cu128
+
+      - name: Install lint dependencies
+        run: ./lint.sh install
+
+      - name: Run lint checks
+        run: ./lint.sh check

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,28 +17,6 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  lint:
-    strategy:
-      fail-fast: true
-      matrix:
-        include:
-          - name: c5.4xlarge
-            runs-on: linux.4xlarge
-            # install the CUDA version to also get triton (needed by pyre type-checking)
-            torch-spec: '--pre torch --index-url https://download.pytorch.org/whl/nightly/cu126'
-    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
-    with:
-      timeout: 60
-      runner: ${{ matrix.runs-on }}
-      submodules: recursive
-      script: |
-        conda create -n venv python=3.10 -y
-        conda activate venv
-        python -m pip install --upgrade pip
-        pip install ${{ matrix.torch-spec }}
-        ./.github/scripts/install_triton.sh
-        ./lint.sh install
-        ./lint.sh check
   test_cuda126_py310_a10g:
     name: test-cuda12.6-py3.10-a10g
     strategy:

--- a/lint.sh
+++ b/lint.sh
@@ -9,40 +9,8 @@ fi
 if [ "$ACTION" = "install" ];
 then
     set -ex
-    # NOTE: Unfortunately the pyre-check binary from pip expects GLIBC_2.29 but our CI machine's linux image only has GLIBC_2.28.
-    # So we have to build the pyre-check binary from source. (See https://github.com/facebook/pyre-check/issues/985)
-    # Q: If we are building from source anyway, why do we still need to do `pip install pyre-check==0.9.23`?
-    # A: I tried that and the from-source Python client actually generates many more type errors (likely related to `typeshed` config).
-    #    So in the interest of time, I decided to just use the pip-installed version for the Python client, but use the from-source version for the server binary.
-    pip install ruff==0.9.8 pyre-check==0.9.23
-    (
-        mkdir -p /tmp/$USER
-        pushd /tmp/$USER
-        rm -rf pyre-check-for-helion/ || true
-        git clone https://github.com/facebook/pyre-check.git -b v0.9.23 pyre-check-for-helion/
-        (
-            pushd pyre-check-for-helion/
-
-            # Install toolchain
-            conda config --set channel_priority strict
-            conda install -y -c conda-forge conda=25.3.1 conda-libmamba-solver
-            conda config --set solver libmamba
-            conda install -y -c conda-forge "rust>=1.77"
-            conda install -y -c conda-forge bubblewrap opam
-
-            # Build pyre-check
-            ./scripts/setup.sh --local --no-tests
-            install -m755 ./source/_build/default/main.exe "$CONDA_PREFIX/bin/pyre.bin"
-            rm -rf ./source/_build/
-
-            ldd --version  # shows the host's GLIBC version
-            conda run pyre.bin --version  # check there is no GLIBC version mismatch
-
-            popd
-        )
-        rm -rf pyre-check-for-helion/
-        popd
-    )
+    # pyre requires click<8.2
+    pip install ruff==0.11.9 pyre-check==0.9.23 click==8.1.0
     exit 0
 fi
 


### PR DESCRIPTION
This allows us to `pip install pyre-check` rather than building from source by using a newer ubuntu image.

It also fixed a conflict between pyre and click 8.2 by downgrading click.