### PR TITLE
Force lint to use click<8.2.0

### DIFF
--- a/lint.sh
+++ b/lint.sh
@@ -14,7 +14,8 @@ then
     # Q: If we are building from source anyway, why do we still need to do `pip install pyre-check==0.9.23`?
     # A: I tried that and the from-source Python client actually generates many more type errors (likely related to `typeshed` config).
     #    So in the interest of time, I decided to just use the pip-installed version for the Python client, but use the from-source version for the server binary.
-    pip install ruff==0.9.8 pyre-check==0.9.23
+    # click 8.2.0 breaks pyre check
+    pip install ruff==0.9.8 "click<8.2.0" pyre-check==0.9.23
     (
         mkdir -p /tmp/$USER
         pushd /tmp/$USER


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #32

