### PR TITLE
Fix TensorDescriptor handling in _find_device

### DIFF
--- a/helion/_compat.py
+++ b/helion/_compat.py
@@ -23,14 +23,20 @@ def _supports_tensor_descriptor() -> bool:
     if major < 9:
         return False
     try:
-        return get_triton_tensor_descriptor_import_path() is not None
+        return get_triton_tensor_descriptor_class() is not None
     except ImportError:
         return False
 
 
 @functools.cache
-def get_triton_tensor_descriptor_import_path() -> str:
-    """Attempt to import TensorDescriptor object from known Triton modules."""
+def get_triton_tensor_descriptor_class_import_path() -> str:
+    cls = get_triton_tensor_descriptor_class()
+    return f"from {cls.__module__} import {cls.__qualname__}"
+
+
+@functools.cache
+def get_triton_tensor_descriptor_class() -> type[object]:
+    """Attempt to import TensorDescriptor class from known Triton modules."""
     possible_modules = [
         "triton.tools.experimental_descriptor",
         "triton.tools.tensor_descriptor",
@@ -39,10 +45,12 @@ def get_triton_tensor_descriptor_import_path() -> str:
         try:
             module = importlib.import_module(module_name)
             if hasattr(module, "TensorDescriptor"):
-                return f"from {module_name} import TensorDescriptor"
+                return module.TensorDescriptor
         except ImportError:
             continue
-    raise ImportError("TensorDescriptor not found in any of the known Triton modules.")
+    raise ImportError(
+        "TensorDescriptor class not found in any of the known Triton modules."
+    )
 
 
 @functools.cache

--- a/helion/_compiler/output_header.py
+++ b/helion/_compiler/output_header.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING
 
 from .. import exc
 from .ast_read_writes import ReadWrites
-from helion._compat import get_triton_tensor_descriptor_import_path
+from helion._compat import get_triton_tensor_descriptor_class_import_path
 from helion._compat import supports_tensor_descriptor
 
 if TYPE_CHECKING:
@@ -24,7 +24,9 @@ library_imports: dict[str, str] = {
 }
 
 if supports_tensor_descriptor():
-    library_imports["TensorDescriptor"] = get_triton_tensor_descriptor_import_path()
+    library_imports["TensorDescriptor"] = (
+        get_triton_tensor_descriptor_class_import_path()
+    )
 
 disallowed_names: dict[str, None] = dict.fromkeys(
     [

--- a/helion/runtime/kernel.py
+++ b/helion/runtime/kernel.py
@@ -13,6 +13,8 @@ import torch
 from torch._inductor.codecache import PyCodeCache
 
 from .. import exc
+from .._compat import get_triton_tensor_descriptor_class
+from .._compat import supports_tensor_descriptor
 from .._compiler.ast_extension import unparse
 from .._compiler.compile_environment import CompileEnvironment
 from .._compiler.generate_ast import generate_ast
@@ -503,6 +505,10 @@ def _find_device(args: tuple[object, ...]) -> torch.device:
     for arg in args:
         if isinstance(arg, torch.Tensor):
             return arg.device
+        if supports_tensor_descriptor() and isinstance(
+            arg, get_triton_tensor_descriptor_class()
+        ):
+            return arg.base.device  # pyre-ignore[16]
         if isinstance(arg, (tuple, list)):
             for item in arg:
                 try:

--- a/test/test_matmul.py
+++ b/test/test_matmul.py
@@ -8,7 +8,7 @@ import torch
 
 import helion
 from helion import Config
-from helion._compat import get_triton_tensor_descriptor_import_path
+from helion._compat import get_triton_tensor_descriptor_class_import_path
 from helion._compat import supports_tensor_descriptor
 from helion._testing import DEVICE
 from helion._testing import code_and_output
@@ -355,7 +355,7 @@ from __future__ import annotations
 import torch
 import triton
 import triton.language as tl
-{get_triton_tensor_descriptor_import_path()}
+{get_triton_tensor_descriptor_class_import_path()}
 
 @triton.jit
 def _matmul_kernel(x_desc, y_desc, out_desc, m, n, k, _BLOCK_SIZE_0: tl.constexpr, _BLOCK_SIZE_1: tl.constexpr, _BLOCK_SIZE_2: tl.constexpr):


### PR DESCRIPTION
Running `examples/matmul.py` on latest Triton gives the following error:
```
$ python examples/matmul.py 
[0s] Starting DifferentialEvolutionSearch with population=40, generations=20, crossover_rate=0.8
Traceback (most recent call last):
  File "/home/willfeng/local/helion_yf225/examples/matmul.py", line 41, in <module>
    check(1024, 1024, 1024)
    ~~~~~^^^^^^^^^^^^^^^^^^
  File "/home/willfeng/local/helion_yf225/examples/matmul.py", line 31, in check
    result = matmul(x, y)
  File "/home/willfeng/local/helion_yf225/helion/runtime/kernel.py", line 188, in __call__
    return self.bind(args)(*args)
           ~~~~~~~~~~~~~~~^^^^^^^
  File "/home/willfeng/local/helion_yf225/helion/runtime/kernel.py", line 383, in __call__
    self.autotune(args)
    ~~~~~~~~~~~~~^^^^^^
  File "/home/willfeng/local/helion_yf225/helion/runtime/kernel.py", line 353, in autotune
    ).autotune()
      ~~~~~~~~^^
  File "/home/willfeng/local/helion_yf225/helion/autotuner/base_search.py", line 192, in autotune
    best = self._autotune()
  File "/home/willfeng/local/helion_yf225/helion/autotuner/differential_evolution.py", line 98, in _autotune
    self.initial_two_generations()
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "/home/willfeng/local/helion_yf225/helion/autotuner/differential_evolution.py", line 60, in initial_two_generations
    self.parallel_benchmark_flat(
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
        self.config_gen.random_population_flat(self.population_size * 2),
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    ),
    ^
  File "/home/willfeng/local/helion_yf225/helion/autotuner/base_search.py", line 302, in parallel_benchmark_flat
    to_check, configs, self.parallel_benchmark(configs), strict=True
                       ~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^
  File "/home/willfeng/local/helion_yf225/helion/autotuner/base_search.py", line 163, in parallel_benchmark
    [
    ...<4 lines>...
    ]
  File "/home/willfeng/local/helion_yf225/helion/autotuner/base_search.py", line 139, in start_precompile_and_check_for_hangs
    precompiler = fn.make_precompiler(*self.args)
  File "/tmp/torchinductor_willfeng/sc/cscnmkivqhfa26e2cqhfogydzs4jl73jnssc3hszwaxvvwrhas4o.py", line 49, in _matmul_make_precompiler
    return make_precompiler(_matmul_kernel)(TensorDescriptor.from_tensor(x, [_BLOCK_SIZE_0, _BLOCK_SIZE_2]), TensorDescriptor.from_tensor(y, [_BLOCK_SIZE_2, _BLOCK_SIZE_1]), TensorDescriptor.from_tensor(out, [_BLOCK_SIZE_0, _BLOCK_SIZE_1]), _BLOCK_SIZE_1, _BLOCK_SIZE_0, _BLOCK_SIZE_2, num_warps=1, num_stages=6)
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/willfeng/local/helion_yf225/helion/runtime/precompile_shim.py", line 24, in _make_precompiler
    device = _find_device([*args, *kwargs.values()])
  File "/home/willfeng/local/helion_yf225/helion/runtime/kernel.py", line 518, in _find_device
    raise exc.NoTensorArgs
helion.exc.NoTensorArgs: Kernel took no tensor args, unclear what device to use.
```
I believe it's due to `_find_device` not being able to extract the device from a `TensorDescriptor` input type. This PR fixes it.