### PR TITLE
Add ../pytorch-nightly to Pyre optional_search_path

### DIFF
--- a/.pyre_configuration
+++ b/.pyre_configuration
@@ -10,7 +10,7 @@
       "source": "examples"
     }
   ],
-  "optional_search_path": ["../pytorch", "../pytorch-hg"],
+  "optional_search_path": ["../pytorch", "../pytorch-hg", "../pytorch-nightly"],
   "python_version": "3.10",
   "exclude": [".*third_party.*"],
   "strict": true


### PR DESCRIPTION
On local development, I have the PyTorch nightly pip install'ed into the `../pytorch-nightly` folder for easier file access. Would like to add this search path to Pyre config as well so that I can run lint check locally.