### PR TITLE
Add HELION_USE_DEFAULT_CONFIG env var to force use default config

### DIFF
--- a/helion/runtime/settings.py
+++ b/helion/runtime/settings.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import dataclasses
 import logging
 import sys
+import os
 import threading
 from typing import TYPE_CHECKING
 from typing import Literal
@@ -88,6 +89,8 @@ class Settings(_Settings):
             settings = {**defaults.to_dict(), **settings}
         # pyre-ignore[6]
         super().__init__(**settings)
+        if os.getenv("HELION_USE_DEFAULT_CONFIG") == "1":
+            self.use_default_config = True
 
     def to_dict(self) -> dict[str, object]:
         """

--- a/helion/runtime/settings.py
+++ b/helion/runtime/settings.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 import dataclasses
 import logging
-import sys
 import os
+import sys
 import threading
 from typing import TYPE_CHECKING
 from typing import Literal
@@ -90,7 +90,7 @@ class Settings(_Settings):
         # pyre-ignore[6]
         super().__init__(**settings)
         if os.getenv("HELION_USE_DEFAULT_CONFIG") == "1":
-            self.use_default_config = True
+            self.use_default_config: bool = True
 
     def to_dict(self) -> dict[str, object]:
         """


### PR DESCRIPTION
Added in https://github.com/pytorch-labs/helion/pull/9, `use_default_config` is very helpful when we care about the lowering part but not the performance part of the Helion kernel compilation workflow.

It's common to want to run the examples in `examples/` folder to quickly check if the lowering part is working, and with the `HELION_USE_DEFAULT_CONFIG` env var introduced in this PR, we can easily do so without needing to go into the example file to manually add `use_default_config=True`.