### PR TITLE
Make BlockSizeOrigin host_str return 1 for block_size=1 case

### DIFF
--- a/helion/_compiler/variable_origin.py
+++ b/helion/_compiler/variable_origin.py
@@ -224,11 +224,18 @@ class BlockSizeOrigin(Origin):
     block_size_idx: int
 
     def host_str(self) -> str:
+        """
+        Get the host-side string representation of a block size variable.
+        If the block size variable was not created (e.g., block size == 1),
+        return the literal '1'.
+        """
         from .device_function import DeviceFunction
 
-        host_str = DeviceFunction.current().block_size_var(self.block_size_idx)
-        assert host_str is not None
-        return host_str
+        # Look up the block size variable name; if not set (e.g., size==1), use literal 1
+        var = DeviceFunction.current().block_size_var(self.block_size_idx)
+        if var is None:
+            return "1"
+        return var
 
 
 @dataclasses.dataclass


### PR DESCRIPTION
Currently, `examples/add.py` fails with the following error:
```
$ python examples/add.py 
[0s] Starting DifferentialEvolutionSearch with population=40, generations=20, crossover_rate=0.8
Traceback (most recent call last):
  File "/home/willfeng/local/helion/helion/_compiler/ast_extension.py", line 218, in visit
    return visitor(node)
  File "/home/willfeng/local/helion/helion/_compiler/generate_ast.py", line 174, in visit_For
    codegen_call_with_graph(
    ~~~~~~~~~~~~~~~~~~~~~~~^
        self,
        ^^^^^
        self.host_fn.device_ir.get_root(self.device_function.config),
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        [],
        ^^^
    )
    ^
  File "/home/willfeng/local/helion/helion/_compiler/inductor_lowering.py", line 711, in codegen_call_with_graph
    return GraphInterpreter(gm, cg).run(*new_args)
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^
  File "/home/willfeng/local/pytorch-nightly/torch/fx/interpreter.py", line 171, in run
    self.env[node] = self.run_node(node)
                     ~~~~~~~~~~~~~^^^^^^
  File "/home/willfeng/local/helion/helion/_compiler/inductor_lowering.py", line 670, in run_node
    result = lowering.codegen(self, n)
  File "/home/willfeng/local/helion/helion/_compiler/inductor_lowering.py", line 434, in codegen
    return self.api_func._codegen(
           ~~~~~~~~~~~~~~~~~~~~~~^
        CodegenState(
        ^^^^^^^^^^^^^
    ...<6 lines>...
        ),
        ^^
    )
    ^
  File "/home/willfeng/local/helion/helion/language/memory_ops.py", line 70, in _
    return state.device_function.indexing_strategy.codegen_load(
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
        state, tensor, [*subscript]
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "/home/willfeng/local/helion/helion/_compiler/indexing_strategy.py", line 126, in codegen_load
    f"{indexing.tensor_descriptor(state)}.load({indexing.offsets_str()})"
       ~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^
  File "/home/willfeng/local/helion/helion/_compiler/indexing_strategy.py", line 297, in tensor_descriptor
    return state.device_function.tensor_descriptor_arg(
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
        self.base, self.block_shape
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    ).name
    ^
  File "/home/willfeng/local/helion/helion/_compiler/device_function.py", line 249, in tensor_descriptor_arg
    block_size_expr = ", ".join(
        map(HostFunction.current().literal_expr, block_size)
    )
  File "/home/willfeng/local/helion/helion/_compiler/host_function.py", line 192, in literal_expr
    return self.sympy_expr(expr._sympy_())
           ~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^
  File "/home/willfeng/local/helion/helion/_compiler/host_function.py", line 187, in sympy_expr
    replacements[sym] = sympy.Symbol(origin.host_str(), integer=True)
                                     ~~~~~~~~~~~~~~~^^
  File "/home/willfeng/local/helion/helion/_compiler/variable_origin.py", line 230, in host_str
    assert host_str is not None
           ^^^^^^^^^^^^^^^^^^^^
AssertionError: While executing %load : [num_users=1] = call_function[target=helion.language.memory_ops.load](args = (%x, [%block_size_0, %block_size_1]), kwargs = {})
GraphModule: class <lambda>(torch.nn.Module):
    def forward(self):
         # File: /home/willfeng/local/helion/examples/add.py:21 in add, code: out[tile] = x[tile] + y[tile]
        x: "f16[s17, s27][s27, 1]" = helion_language__tracing_ops__host_tensor('x')
        block_size_0: "Sym(u0)" = helion_language__tracing_ops__get_symnode('block_size_0')
        block_size_1: "Sym(u1)" = helion_language__tracing_ops__get_symnode('block_size_1')
        load: "f16[u0, u1][Max(1, u1), 1]" = helion_language_memory_ops_load(x, [block_size_0, block_size_1]);  x = None
        y: "f16[s17, s27][s27, 1]" = helion_language__tracing_ops__host_tensor('y')
        load_1: "f16[u0, u1][Max(1, u1), 1]" = helion_language_memory_ops_load(y, [block_size_0, block_size_1]);  y = None
        add: "f16[u0, u1][Max(1, u1), 1]" = torch.ops.aten.add.Tensor(load, load_1);  load = load_1 = None
        out: "f16[s17, s27][s27, 1]" = helion_language__tracing_ops__host_tensor('out')
        store = helion_language_memory_ops_store(out, [block_size_0, block_size_1], add);  out = block_size_0 = block_size_1 = add = store = None
        return None
        

Original traceback:
  File "/home/willfeng/local/helion/examples/add.py", line 21, in add
    out[tile] = x[tile] + y[tile]


The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/willfeng/local/helion/examples/add.py", line 40, in <module>
    check(1024, 1024)
    ~~~~~^^^^^^^^^^^^
  File "/home/willfeng/local/helion/examples/add.py", line 30, in check
    result = add(x, y)
  File "/home/willfeng/local/helion/helion/runtime/kernel.py", line 190, in __call__
    return self.bind(args)(*args)
           ~~~~~~~~~~~~~~~^^^^^^^
  File "/home/willfeng/local/helion/helion/runtime/kernel.py", line 385, in __call__
    self.autotune(args)
    ~~~~~~~~~~~~~^^^^^^
  File "/home/willfeng/local/helion/helion/runtime/kernel.py", line 355, in autotune
    ).autotune()
      ~~~~~~~~^^
  File "/home/willfeng/local/helion/helion/autotuner/base_search.py", line 192, in autotune
    best = self._autotune()
  File "/home/willfeng/local/helion/helion/autotuner/differential_evolution.py", line 98, in _autotune
    self.initial_two_generations()
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "/home/willfeng/local/helion/helion/autotuner/differential_evolution.py", line 60, in initial_two_generations
    self.parallel_benchmark_flat(
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
        self.config_gen.random_population_flat(self.population_size * 2),
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    ),
    ^
  File "/home/willfeng/local/helion/helion/autotuner/base_search.py", line 302, in parallel_benchmark_flat
    to_check, configs, self.parallel_benchmark(configs), strict=True
                       ~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^
  File "/home/willfeng/local/helion/helion/autotuner/base_search.py", line 160, in parallel_benchmark
    fns = [self.kernel.compile_config(c) for c in configs]
           ~~~~~~~~~~~~~~~~~~~~~~~~~~^^^
  File "/home/willfeng/local/helion/helion/runtime/kernel.py", line 307, in compile_config
    triton_code = self.to_triton_code(config)
  File "/home/willfeng/local/helion/helion/runtime/kernel.py", line 291, in to_triton_code
    root = generate_ast(self.host_fn, config)
  File "/home/willfeng/local/helion/helion/_compiler/generate_ast.py", line 312, in generate_ast
    codegen.add_statement(codegen.visit(stmt))
                          ~~~~~~~~~~~~~^^^^^^
  File "/home/willfeng/local/helion/helion/_compiler/ast_extension.py", line 222, in visit
    raise exc.InternalError(e) from e
helion.exc.InternalError: AssertionError: While executing %load : [num_users=1] = call_function[target=helion.language.memory_ops.load](args = (%x, [%block_size_0, %block_size_1]), kwargs = {})
GraphModule: class <lambda>(torch.nn.Module):
    def forward(self):
         # File: /home/willfeng/local/helion/examples/add.py:21 in add, code: out[tile] = x[tile] + y[tile]
        x: "f16[s17, s27][s27, 1]" = helion_language__tracing_ops__host_tensor('x')
        block_size_0: "Sym(u0)" = helion_language__tracing_ops__get_symnode('block_size_0')
        block_size_1: "Sym(u1)" = helion_language__tracing_ops__get_symnode('block_size_1')
        load: "f16[u0, u1][Max(1, u1), 1]" = helion_language_memory_ops_load(x, [block_size_0, block_size_1]);  x = None
        y: "f16[s17, s27][s27, 1]" = helion_language__tracing_ops__host_tensor('y')
        load_1: "f16[u0, u1][Max(1, u1), 1]" = helion_language_memory_ops_load(y, [block_size_0, block_size_1]);  y = None
        add: "f16[u0, u1][Max(1, u1), 1]" = torch.ops.aten.add.Tensor(load, load_1);  load = load_1 = None
        out: "f16[s17, s27][s27, 1]" = helion_language__tracing_ops__host_tensor('out')
        store = helion_language_memory_ops_store(out, [block_size_0, block_size_1], add);  out = block_size_0 = block_size_1 = add = store = None
        return None
        

Original traceback:
  File "/home/willfeng/local/helion/examples/add.py", line 21, in add
    out[tile] = x[tile] + y[tile]
```
`host_str` is None here
https://github.com/pytorch-labs/helion/blob/bd3d984db69504d264ef7752b98371732df55b34/helion/_compiler/variable_origin.py#L229 because `block_size_var_cache` doesn't contain entry for this specific block_size_idx, which is in turn because we skip bs=1 case in https://github.com/pytorch-labs/helion/blob/bd3d984db69504d264ef7752b98371732df55b34/helion/_compiler/tile_strategy.py#L367-L370

However, the host-side string representation of a block size variable should not be None in general, so in this PR we return `"1"` for the bs=1 case. 


Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #39
* __->__ #38

