### PR TITLE
[2nd try] Make BlockSizeOrigin host_str return 1 for block_size=1 case

### DIFF
--- a/helion/_compiler/variable_origin.py
+++ b/helion/_compiler/variable_origin.py
@@ -224,11 +224,18 @@ class BlockSizeOrigin(Origin):
     block_size_idx: int
 
     def host_str(self) -> str:
+        """
+        Get the host-side string representation of a block size variable.
+        If the block size variable was not created (e.g., block size == 1),
+        return the literal '1'.
+        """
         from .device_function import DeviceFunction
 
-        host_str = DeviceFunction.current().block_size_var(self.block_size_idx)
-        assert host_str is not None
-        return host_str
+        # Look up the block size variable name; if not set (e.g., size==1), use literal 1
+        var = DeviceFunction.current().block_size_var(self.block_size_idx)
+        if var is None:
+            return "1"
+        return var
 
 
 @dataclasses.dataclass


### PR DESCRIPTION
Same as https://github.com/pytorch-labs/helion/pull/38. I accidentally used the github merge button where I should have used `@pytorchbot merge` instead.

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #39
* __->__ #40

