### PR TITLE
Minor fix on the matmul example dim notation

### DIFF
--- a/examples/matmul.py
+++ b/examples/matmul.py
@@ -23,11 +23,11 @@ def matmul(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
     return out
 
 
-def check(n: int, k: int, m: int) -> None:
+def check(m: int, k: int, n: int) -> None:
     from triton.testing import do_bench
 
-    x = torch.randn([n, k], device="cuda", dtype=torch.float16)
-    y = torch.randn([k, m], device="cuda", dtype=torch.float16)
+    x = torch.randn([m, k], device="cuda", dtype=torch.float16)
+    y = torch.randn([k, n], device="cuda", dtype=torch.float16)
     result = matmul(x, y)
     torch.testing.assert_close(result, x @ y, rtol=1e-2, atol=1e-1)
     sec = do_bench(lambda: matmul(x, y))


### PR DESCRIPTION
Following the lines in the `matmul` kernel:
https://github.com/pytorch-labs/helion/blob/96253e7faf936dfcdf7c2484e561a5c5e30a7b02/examples/matmul.py#L12-L13
I believe x should be of `[m, k]` shape and y should be of `[k, n]` shape, so updating the `check()` function to use the same notation.

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #47

