### PR TITLE
Fix CI actions running double

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,8 +1,8 @@
 name: Lint
 
 on:
+  pull_request:
   push:
-    pull_request:
     branches:
       - main
       - release/*

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,14 +2,10 @@ name: Lint
 
 on:
   push:
+    pull_request:
     branches:
       - main
-      # Include any branch created via ghstack
-      - gh/**
-  pull_request:
-    branches:
-      - main
-      - gh/*
+      - release/*
 
 jobs:
   lint:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,8 +1,8 @@
 name: Run Tests
 
 on:
+  pull_request:
   push:
-    pull_request:
     branches:
       - main
       - release/*

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,15 +2,10 @@ name: Run Tests
 
 on:
   push:
+    pull_request:
     branches:
       - main
-      # Include any branch that is created via ghstack
-      - gh/**
-  pull_request:
-    branches:
-      - main
-      # Include any branch that is created via ghstack
-      - gh/**
+      - release/*
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref == 'refs/heads/main' && github.run_number || github.ref }}


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #54

I have noticed that we are running workflows double on ghstack based pull requests, i think it is triggering twice due the hooks, one for push and one for pull request. Hopefully this copy-pasted from pytorch trigger fixes it. Source: https://github.com/pytorch/pytorch/blob/main/.github/workflows/lint.yml
