### PR TITLE
Add attention example and fix some bugs

### DIFF
--- a/examples/attention.py
+++ b/examples/attention.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+import math
+
+import torch
+from torch.nn.attention.flex_attention import flex_attention
+
+import helion
+import helion.language as hl
+
+
+@helion.kernel(
+    config=helion.Config(
+        # This config was autotuned on a 3090, it won't be fast for other architectures
+        block_sizes=[[32], [16]],
+        num_warps=1,
+        num_stages=2,
+        indexing="block_ptr",
+    ),
+    static_shapes=True,
+)
+def attention(
+    q_in: torch.Tensor,
+    k_in: torch.Tensor,
+    v_in: torch.Tensor,
+) -> torch.Tensor:
+    m_dim = q_in.size(-2)
+    n_dim = k_in.size(-2)
+    head_dim = q_in.size(-1)
+    assert n_dim == v_in.size(-2)
+    assert head_dim == k_in.size(-1) == v_in.size(-1)
+    q_view = q_in.reshape([-1, m_dim, head_dim])
+    v_view = v_in.reshape([-1, n_dim, head_dim])
+    k_view = k_in.reshape([-1, n_dim, head_dim]).transpose(1, 2)
+    out = torch.empty_like(q_view)
+    sm_scale = 1.0 / math.sqrt(head_dim)
+    qk_scale = sm_scale * 1.44269504  # 1/log(2)
+    for tile_b, tile_m in hl.tile([q_view.size(0), m_dim], block_size=[1, None]):
+        m_i = hl.full([tile_b, tile_m], float("-inf"), dtype=torch.float32)
+        l_i = torch.full_like(m_i, 1.0)
+        acc = hl.zeros([tile_b, tile_m, head_dim], dtype=torch.float32)
+        q = q_view[tile_b, tile_m, :]
+        for tile_n in hl.tile(v_view.size(1)):
+            # compute qk
+            k = k_view[tile_b, :, tile_n]
+            qk = torch.bmm(q, k)
+            m_ij = torch.maximum(m_i, torch.amax(qk, -1) * qk_scale)
+            qk = qk * qk_scale - m_ij[:, :, None]
+            p = torch.exp2(qk)
+            l_ij = torch.sum(p, -1)
+            # update m_i and l_i
+            alpha = torch.exp2(m_i - m_ij)
+            l_i = l_i * alpha + l_ij
+            acc = acc * alpha[:, :, None]
+            v = v_view[tile_b, tile_n, :]
+            p = p.to(v.dtype)
+            acc = torch.baddbmm(acc, p, v)
+            m_i = m_ij
+        m_i += torch.log2(l_i)
+        acc = acc / l_i[:, :, None]
+        out[tile_b, tile_m, :] = acc.to(out.dtype)
+    return out.view(q_in.size())
+
+
+def test(
+    z: int,
+    h: int,
+    n_ctx: int,
+    head_dim: int,
+    dtype: torch.dtype = torch.float32,
+    device: torch.device | str = "cuda",
+) -> None:
+    q, k, v = [
+        torch.randn((z, h, n_ctx, head_dim), dtype=dtype, device=device)
+        for _ in range(3)
+    ]
+
+    # reference implementation
+    p = torch.matmul(q, k.transpose(2, 3)) / math.sqrt(head_dim)
+    p = torch.softmax(p.float(), dim=-1).to(dtype)
+    ref_out = torch.matmul(p, v)
+
+    # flex attention version
+    # TODO(jansel): turn the above kernel into a flex attention kernel
+    flex_out = flex_attention(q, k, v)
+    torch.testing.assert_close(flex_out, ref_out, atol=1e-2, rtol=1e-2)
+
+    # sdpa version
+    sdpa_out = torch.nn.functional.scaled_dot_product_attention(q, k, v)
+    torch.testing.assert_close(sdpa_out, ref_out, atol=1e-2, rtol=1e-2)
+
+    # helion version
+    hl_out = attention(q, k, v)
+    torch.testing.assert_close(hl_out, ref_out, atol=1e-2, rtol=1e-2)
+
+    # benchmark
+    from triton.testing import do_bench
+
+    spda_sec = do_bench(
+        lambda: torch.nn.functional.scaled_dot_product_attention(q, k, v)
+    )
+    flex_sec = do_bench(lambda: flex_attention(q, k, v))
+    helion_sec = do_bench(lambda: attention(q, k, v))
+    print(
+        f"Helion time: {helion_sec:.4f}s, flex time: {flex_sec:.4f}, torch time: {spda_sec:.4f}"
+    )
+
+
+if __name__ == "__main__":
+    test(2, 32, 1024, 64, torch.float16)

--- a/helion/_compiler/inductor_lowering.py
+++ b/helion/_compiler/inductor_lowering.py
@@ -623,10 +623,11 @@ def apply_dot_requirements(handler: CodegenHandler, node: torch.fx.Node) -> Lowe
     for shape, min_size in [(n, a), (k, b), (m, c)]:
         block_idx = TileStrategy.get_block_index(shape)
         if block_idx is not None:
-            env.config_spec.update_min_block(block_idx, min_size, allow_flattened=False)
+            env.block_sizes[block_idx].update_min_block(min_size, allow_flattened=True)
     return LambdaLowering(handler)
 
 
+@register_lowering(torch.ops.aten.bmm.default, apply_dot_requirements)
 # pyre-fixme[56]
 @register_lowering(torch.ops.aten.mm.default, apply_dot_requirements)
 def codegen_mm(ctx: GraphInterpreter, node: torch.fx.Node) -> ast.AST:

--- a/helion/_compiler/output_header.py
+++ b/helion/_compiler/output_header.py
@@ -21,6 +21,7 @@ library_imports: dict[str, str] = {
     "tl": "import triton.language as tl",
     "triton_helpers": "from torch._inductor.runtime import triton_helpers",
     "tl_math": "from torch._inductor.runtime.triton_helpers import math as tl_math",
+    "libdevice": "from torch._inductor.runtime.triton_compat import libdevice",
 }
 
 if supports_tensor_descriptor():

--- a/helion/autotuner/config_spec.py
+++ b/helion/autotuner/config_spec.py
@@ -57,21 +57,6 @@ class ConfigSpec:
             if spec.allow_reorder
         ]
 
-    def update_min_block(
-        self, block_idx: int, value: int, *, allow_flattened: bool = True
-    ) -> None:
-        """
-        Update the minimum block size for the given block index, only increasing the minimum size.
-        """
-        i = block_idx
-        for spec in self.block_size_specs:
-            if i < len(spec):
-                spec.update_min(i, value)
-                spec.allow_flattened = spec.allow_flattened and allow_flattened
-                return
-            i -= len(spec)
-        raise IndexError(f"{block_idx} is out of range for {self.block_size_specs}")
-
     def normalize(self, config: helion.Config | dict[str, object]) -> None:
         """Normalize the config to match the block_sizes and validate the config."""
         if isinstance(config, helion.Config):

--- a/helion/language/_tracing_ops.py
+++ b/helion/language/_tracing_ops.py
@@ -82,6 +82,8 @@ def _(state: CodegenState) -> None:
     return HostFunction.current().device_ir.graphs[state.proxy_arg(1)].codegen(state)
 
 
+# Note we can't DCE phi nodes because there may be a loop carry dependency not captured in the outer graph
+@has_side_effect
 @_decorators.api()
 def _phi(lhs: object, rhs: object) -> object:
     """Combine values from different branches of a control flow."""

--- a/helion/language/loops.py
+++ b/helion/language/loops.py
@@ -35,7 +35,7 @@ __all__ = ["register_block_size", "tile"]
 @_decorators.api(
     is_device_loop=True, is_device_only=False, cache_type=True, tiles_as_sizes=True
 )
-def tile(sizes: int, block_size: TileOutput | None = None) -> Iterator[TileOutput]: ...
+def tile(sizes: int, block_size: object = None) -> Iterator[TileOutput]: ...
 
 
 @overload
@@ -43,7 +43,7 @@ def tile(sizes: int, block_size: TileOutput | None = None) -> Iterator[TileOutpu
     is_device_loop=True, is_device_only=False, cache_type=True, tiles_as_sizes=True
 )
 def tile(
-    sizes: Sequence[int], block_size: Sequence[TileOutput] | None = None
+    sizes: Sequence[int], block_size: object = None
 ) -> Iterator[Sequence[TileOutput]]: ...
 
 
@@ -52,7 +52,7 @@ def tile(
 )
 def tile(
     sizes: int | Sequence[int],
-    block_size: TileOutput | Sequence[TileOutput] | None = None,
+    block_size: object = None,
 ) -> Iterator[TileOutput] | Iterator[Sequence[TileOutput]]:
     """
     Break up an iteration space defined by a size or sequence of sizes into tiles.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ select = [
     "G", "I", "ISC", "LOG", "NPY", "PERF", "PGH004", "PIE", "PLC0131", "PLC0132",
     "PLC0205", "PLC0208", "PLC2401", "PLC3002", "PLE", "PLR0133", "PLR0206",
     "PLR1722", "PLR1736", "PLW0129", "PLW0131", "PLW0133", "PLW0245", "PLW0406",
-    "PLW0711", "PLW1501", "PLW1509", "PLW2101", "PLW3301", "PT", "PYI", "Q", "RET",
+    "PLW0711", "PLW1501", "PLW1509", "PLW2101", "PLW3301", "PYI", "Q", "RET",
     "RSE", "RUF005", "RUF007", "RUF008", "RUF009", "RUF010", "RUF012", "RUF013",
     "RUF015", "RUF016", "RUF017", "RUF018", "RUF019", "RUF020", "RUF022", "RUF024",
     "RUF026", "RUF030", "RUF034", "RUF036", "RUF037", "RUF041", "RUF047", "RUF051",
@@ -58,7 +58,7 @@ select = [
 ]
 ignore = [
     "C409", "C419", "COM812", "E501", "ERA001", "FURB189", "G004", "PERF203",
-    "PERF401", "PT009", "SIM102", "SIM108", "SIM115", "UP035", "UP038",
+    "PERF401", "SIM102", "SIM108", "SIM115", "UP035", "UP038",
 ]
 extend-safe-fixes = ["TC", "UP045", "RUF013", "RSE102"]
 preview = true


### PR DESCRIPTION
Still a bunch of issues that need fixing:
1) The generated code is slow.  I think this is because we are using `[1, N, M]` tiles rather than `[N, M]` tiles and Triton generates bad code for 3D tiles.  Need to implement a "drop size==1 dims" pass.
2) It looks like we are hardcoding `sm_scale` and `head_dim` in the generated code.  I think this is because of the call to `math.sqrt`, but need to look into it.
3) We have some unnecessary masking for the reductions (and missing masking for the dot if shapes are non-multiples).  Need to polish the masking logic.