### PR TITLE
Support python test/test_X.py command for all unit test files

### DIFF
--- a/test/test_autotuner.py
+++ b/test/test_autotuner.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from pathlib import Path
 import random
 import tempfile
+import unittest
 from unittest.mock import patch
 
 from expecttest import TestCase
@@ -192,3 +193,7 @@ helion.Config(block_sizes=[1], loop_orders=[[2, 1, 0]], num_warps=1, num_stages=
         )
         result = add(*args)
         torch.testing.assert_close(result, sum(args))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_closures.py
+++ b/test/test_closures.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+import unittest
 
 from expecttest import TestCase
 import torch
@@ -303,3 +304,7 @@ def _call_func_arg_on_host_make_precompiler(a, alloc):
     from helion.runtime.precompile_shim import make_precompiler
     return make_precompiler(_call_func_arg_on_host_kernel)(a, out, a.size(0), a.stride(0), out.stride(0), _BLOCK_SIZE_0, num_warps=4, num_stages=3)""",
         )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_constexpr.py
+++ b/test/test_constexpr.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import unittest
+
 from expecttest import TestCase
 import torch
 
@@ -179,3 +181,7 @@ def _fn_make_precompiler(x: torch.Tensor, s: hl.constexpr):
     from helion.runtime.precompile_shim import make_precompiler
     return make_precompiler(_fn_kernel)(x, out, out.stride(0), out.stride(1), x.stride(0), b, _BLOCK_SIZE_0, _BLOCK_SIZE_1, num_warps=4, num_stages=3)""",
         )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_control_flow.py
+++ b/test/test_control_flow.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import unittest
+
 from expecttest import TestCase
 import torch
 
@@ -191,3 +193,7 @@ def _fn_make_precompiler(x):
     from helion.runtime.precompile_shim import make_precompiler
     return make_precompiler(_fn_kernel)(x, out, out.size(0), out.size(1), x.size(0), x.size(1), out.stride(0), out.stride(1), x.stride(0), x.stride(1), _BLOCK_SIZE_0, _BLOCK_SIZE_1, num_warps=4, num_stages=3)""",
         )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_examples.py
+++ b/test/test_examples.py
@@ -1093,3 +1093,7 @@ def _attention_make_precompiler(q_in: torch.Tensor, k_in: torch.Tensor, v_in: to
     from helion.runtime.precompile_shim import make_precompiler
     return make_precompiler(_attention_kernel)(q_view, k_view, v_view, out, _BLOCK_SIZE_1, _BLOCK_SIZE_2, num_warps=4, num_stages=3)""",
         )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_logging.py
+++ b/test/test_logging.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import unittest
+
 from expecttest import TestCase
 import torch
 
@@ -46,3 +48,7 @@ class TestLogging(TestCase):
         self.assertTrue(
             any("DEBUG:helion.runtime.kernel:Debug string:" in msg for msg in cm.output)
         )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_loops.py
+++ b/test/test_loops.py
@@ -441,3 +441,7 @@ def _matmul_make_precompiler(x: torch.Tensor, y: torch.Tensor):
     from helion.runtime.precompile_shim import make_precompiler
     return make_precompiler(_matmul_kernel)(x, y, out, _BLOCK_SIZE_0, _BLOCK_SIZE_1, _BLOCK_SIZE_2, num_warps=4, num_stages=3)""",
         )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_matmul.py
+++ b/test/test_matmul.py
@@ -637,3 +637,7 @@ def matmul_static_shapes(x: torch.Tensor, y: torch.Tensor):
     _matmul_static_shapes_kernel[triton.cdiv(127, _BLOCK_SIZE_0) * triton.cdiv(127, _BLOCK_SIZE_1),](x, y, out, _BLOCK_SIZE_0, _BLOCK_SIZE_1, _BLOCK_SIZE_2, num_warps=4, num_stages=3)
     return out""",
         )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_reductions.py
+++ b/test/test_reductions.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
+import unittest
 
 from expecttest import TestCase
 import torch
@@ -419,3 +420,7 @@ def _reduce_kernel_make_precompiler(x: torch.Tensor, fn: Callable[[torch.Tensor]
     from helion.runtime.precompile_shim import make_precompiler
     return make_precompiler(_reduce_kernel_kernel)(x, out, out.size(0), x.size(0), x.size(1), out.stride(0), x.stride(0), x.stride(1), _m, _REDUCTION_BLOCK_1, num_warps=4, num_stages=3)""",
         )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_views.py
+++ b/test/test_views.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import unittest
+
 from expecttest import TestCase
 import torch
 
@@ -272,3 +274,7 @@ def _fn_make_precompiler(x: torch.Tensor, y: torch.Tensor):
         )
         _code, result = code_and_output(fn, args)
         torch.testing.assert_close(result, args[0] + args[1])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Several of our unit test files already support `python test/test_X.py` command which is convenient for quick testing. This PR adds this support to all remaining unit test files.

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #60

