### PR TITLE
[RFC][Codemod] Rename device/host _fn to _function

### DIFF
--- a/helion/_compiler/device_function.py
+++ b/helion/_compiler/device_function.py
@@ -245,13 +245,13 @@ class DeviceFunction:
     def tensor_descriptor_arg(
         self, fake_value: torch.Tensor, block_size: list[int | torch.SymInt]
     ) -> TensorArg:
-        host_fn = HostFunction.current()
+        host_function = HostFunction.current()
         block_size_expr = ", ".join(
             map(HostFunction.current().literal_expr, block_size)
         )
         key = (fake_value, block_size_expr)
         if key not in self._tensor_descriptor_args:
-            origin = host_fn.tensor_to_origin[fake_value]
+            origin = host_function.tensor_to_origin[fake_value]
             arg = TensorDescriptorArg(
                 self.new_var(origin.suggest_var_name() + "_desc"),
                 fake_value,

--- a/helion/_compiler/lift_closures.py
+++ b/helion/_compiler/lift_closures.py
@@ -36,11 +36,13 @@ def lift_closures(func: FunctionType, origin: Origin) -> FunctionType:
     def wrapper(*args: object, **kwargs: object) -> object:
         nonlocal new_func, closure_contents
         if new_func is None:
-            host_fn = HostFunction.current()
+            host_function = HostFunction.current()
             closure = None
             if func.__closure__ is not None:
                 closure_contents = [
-                    host_fn.register_fake(obj.cell_contents, ClosureOrigin(origin, i))
+                    host_function.register_fake(
+                        obj.cell_contents, ClosureOrigin(origin, i)
+                    )
                     for i, obj in enumerate(func.__closure__)
                 ]
                 closure = (*map(make_cell, closure_contents),)

--- a/helion/_compiler/reduction_strategy.py
+++ b/helion/_compiler/reduction_strategy.py
@@ -235,7 +235,7 @@ class LoopedReductionStrategy(ReductionStrategy):
     def codegen_device_loop(self, state: CodegenState) -> DeviceLoopState:
         env = CompileEnvironment.current()
         block_index = self.block_index
-        device_fn = state.device_function
+        device_function = state.device_function
         numel = env.block_sizes[block_index].numel
         offset_var = self.offset_var(block_index)
         index_var = self.index_var(block_index)
@@ -253,14 +253,14 @@ class LoopedReductionStrategy(ReductionStrategy):
         if (mask_var := self._mask_var) is not None:
             body.append(
                 statement_from_string(
-                    f"{mask_var} = {index_var} < {device_fn.sympy_expr(numel)}"
+                    f"{mask_var} = {index_var} < {device_function.sympy_expr(numel)}"
                 )
             )
         for_node = create(
             ast.For,
             target=create(ast.Name, id=offset_var, ctx=ast.Store()),
             iter=expr_from_string(
-                f"range(0, ({device_fn.sympy_expr(numel)}), {block_size_var})"
+                f"range(0, ({device_function.sympy_expr(numel)}), {block_size_var})"
             ),
             body=body,
             orelse=[],

--- a/helion/_compiler/source_location.py
+++ b/helion/_compiler/source_location.py
@@ -67,14 +67,14 @@ class SourceLocation(traceback.FrameSummary):
     def from_ast(node: ast.AST) -> SourceLocation:
         from .host_function import HostFunction
 
-        host_fn = HostFunction.current()
-        code = host_fn.fn.__code__
+        host_function = HostFunction.current()
+        code = host_function.fn.__code__
         offset = code.co_firstlineno - 1
         return SourceLocation(
             node.lineno + offset,
-            node.col_offset + host_fn.column_offset,
+            node.col_offset + host_function.column_offset,
             node.end_lineno + offset,
-            node.end_col_offset + host_fn.column_offset,
+            node.end_col_offset + host_function.column_offset,
             filename=code.co_filename,
             name=code.co_name,
         )

--- a/helion/runtime/kernel.py
+++ b/helion/runtime/kernel.py
@@ -251,7 +251,7 @@ class BoundKernel:
                 else:
                     self.fake_args.append(self.env.to_fake(arg, ArgumentOrigin(name)))
             with _maybe_skip_dtype_check_in_meta_registrations():
-                self.host_fn: HostFunction = HostFunction(
+                self.host_function: HostFunction = HostFunction(
                     self.kernel.fn, self.fake_args, constexpr_args
                 )
         if len(kernel.configs) == 1:
@@ -301,7 +301,7 @@ class BoundKernel:
                 # pyre-ignore[6]
                 config = Config(**config)
             self.env.config_spec.normalize(config)
-            root = generate_ast(self.host_fn, config)
+            root = generate_ast(self.host_function, config)
             return get_needed_imports(root) + unparse(root)
 
     def compile_config(self, config: ConfigLike) -> CompiledConfig:
@@ -334,7 +334,7 @@ class BoundKernel:
         :rtype: str
         """
         with self.env:
-            return self.host_fn.debug_str()
+            return self.host_function.debug_str()
 
     def autotune(
         self,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #62

There are so places where we use device_fn, host_fn, device_function and host_function. Lets be consistent everywhere. I'm also ok if we want to swap to _fn versions, as long as we are consistent.