### PR TITLE
[Ready for review] Add hl.register_reduction_dim(); add support for matmul+layernorm example

### DIFF
--- a/examples/matmul_layernorm.py
+++ b/examples/matmul_layernorm.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import torch
+
+import helion
+import helion.language as hl
+
+
+# static_shapes=True gives a performance boost for matmuls
+@helion.kernel(static_shapes=True)
+def matmul_layernorm(
+    x: torch.Tensor, y: torch.Tensor, weight: torch.Tensor, bias: torch.Tensor
+) -> torch.Tensor:
+    m, k = x.size()
+    k2 = y.size(0)
+    n = hl.register_reduction_dim(y.size(1))
+    assert k == k2, f"size mismatch {k} != {k2}"
+    assert weight.size(0) == n, f"weight size mismatch {weight.size(0)} != {n}"
+    assert bias.size(0) == n, f"bias size mismatch {bias.size(0)} != {n}"
+    out = torch.empty(
+        [m, n], dtype=torch.promote_types(x.dtype, y.dtype), device=x.device
+    )
+    for tile_m in hl.tile(m):
+        acc = hl.zeros([tile_m, n], dtype=torch.float32)
+        for tile_k in hl.tile(k):
+            mm = torch.matmul(x[tile_m, tile_k], y[tile_k, :])
+            acc = acc + mm
+        eps = 1e-5
+        var, mean = torch.var_mean(acc, dim=-1, keepdim=True, correction=0)
+        normalized = (acc - mean) * torch.rsqrt(var + eps)
+        acc = normalized * (weight[:].to(torch.float32)) + (bias[:].to(torch.float32))
+        out[tile_m, :] = acc
+    return out
+
+
+def matmul_layernorm_pytorch(
+    x: torch.Tensor, y: torch.Tensor, weight: torch.Tensor, bias: torch.Tensor
+) -> torch.Tensor:
+    import torch.nn.functional as F
+
+    matmul_out = torch.matmul(x, y)
+
+    ln_out = F.layer_norm(
+        matmul_out.to(torch.float32),
+        normalized_shape=(matmul_out.shape[-1],),
+        weight=weight.to(torch.float32),
+        bias=bias.to(torch.float32),
+    )
+
+    return ln_out.to(torch.promote_types(x.dtype, y.dtype))
+
+
+def check(m: int, k: int, n: int) -> None:
+    from triton.testing import do_bench
+
+    x = torch.randn([m, k], device="cuda", dtype=torch.float16)
+    y = torch.randn([k, n], device="cuda", dtype=torch.float16)
+    weight = torch.randn([n], device="cuda", dtype=torch.float16)
+    bias = torch.randn([n], device="cuda", dtype=torch.float16)
+    result = matmul_layernorm(x, y, weight, bias)
+    expected = matmul_layernorm_pytorch(x, y, weight, bias)
+    torch.testing.assert_close(result, expected, rtol=1e-2, atol=1e-1)
+    sec = do_bench(lambda: matmul_layernorm(x, y, weight, bias))
+    baseline_sec = do_bench(lambda: matmul_layernorm_pytorch(x, y, weight, bias))
+    print(
+        f"Helion time: {sec:.4f}s, torch time: {baseline_sec:.4f}, speedup: {baseline_sec / sec:.2f}x"
+    )
+
+
+def main() -> None:
+    # TODO(yf225): n=64 or 128 throws error, need to investigate
+    # check(32, 64, 64)
+    # check(32, 64, 128)
+    check(32, 64, 200)
+    check(128, 256, 400)
+
+
+if __name__ == "__main__":
+    main()

--- a/helion/_compiler/compile_environment.py
+++ b/helion/_compiler/compile_environment.py
@@ -99,6 +99,14 @@ class CompileEnvironment:
         hint: int = 64,
     ) -> int:
         idx = len(self.block_sizes)
+        from .host_function import HostFunction
+
+        if isinstance(size, torch.SymInt):
+            # If block size is already allocated, we reuse the existing index.
+            expr = size._sympy_()
+            origin_info = HostFunction.current().expr_to_origin.get(expr)
+            if origin_info and isinstance(origin_info.origin, BlockSizeOrigin):
+                return origin_info.origin.block_size_idx
         self.block_sizes.append(
             info := BlockSizeInfo(
                 block_id=idx,
@@ -112,7 +120,6 @@ class CompileEnvironment:
             )
         )
 
-        from .host_function import HostFunction
         from .host_function import SymbolOrigin
 
         HostFunction.current().expr_to_origin[info.symbol()] = SymbolOrigin(

--- a/helion/_compiler/compile_environment.py
+++ b/helion/_compiler/compile_environment.py
@@ -99,14 +99,6 @@ class CompileEnvironment:
         hint: int = 64,
     ) -> int:
         idx = len(self.block_sizes)
-        from .host_function import HostFunction
-
-        if isinstance(size, torch.SymInt):
-            # If block size is already allocated, we reuse the existing index.
-            expr = size._sympy_()
-            origin_info = HostFunction.current().expr_to_origin.get(expr)
-            if origin_info and isinstance(origin_info.origin, BlockSizeOrigin):
-                return origin_info.origin.block_size_idx
         self.block_sizes.append(
             info := BlockSizeInfo(
                 block_id=idx,
@@ -120,6 +112,7 @@ class CompileEnvironment:
             )
         )
 
+        from .host_function import HostFunction
         from .host_function import SymbolOrigin
 
         HostFunction.current().expr_to_origin[info.symbol()] = SymbolOrigin(
@@ -128,9 +121,24 @@ class CompileEnvironment:
         return idx
 
     def allocate_reduction_dimension(self, size: torch.SymInt | int) -> BlockSizeInfo:
+        # Check if this size is already a registered block size
+        if isinstance(size, torch.SymInt):
+            from .host_function import HostFunction
+
+            expr = size._sympy_()
+            origin_info = HostFunction.current().expr_to_origin.get(expr)
+            if origin_info and isinstance(origin_info.origin, BlockSizeOrigin):
+                block_idx = origin_info.origin.block_id
+                # Return the existing block size if it's a reduction dimension
+                if self.block_sizes[block_idx].reduction:
+                    return self.block_sizes[block_idx]
+
+        # Check for existing reduction dimensions with the same size
         for rdim in self.block_sizes:
             if rdim.reduction and rdim.size == size:
                 return rdim
+
+        # Allocate a new reduction dimension
         rdim_idx = self.allocate_block_size(
             size,
             reduction=True,

--- a/helion/_compiler/device_ir.py
+++ b/helion/_compiler/device_ir.py
@@ -324,13 +324,6 @@ class DeviceIR:
                     break
 
             if not can_roll_graphs:
-                # Can't roll any graphs for this rdim, but still need to add the spec
-                env.config_spec.reduction_loops.append(
-                    ReductionLoopSpec(
-                        block_id=rdim.block_id,
-                        size_hint=rdim.size_hint(),
-                    )
-                )
                 first = False
                 continue
 

--- a/helion/_compiler/device_ir.py
+++ b/helion/_compiler/device_ir.py
@@ -319,16 +319,16 @@ class DeviceIR:
             can_roll_graphs = True
             for graph_info in self.graphs:
                 roller = ReductionRoller(self, rdim, {})
-                if roller.has_matmul_with_rdim(graph_info.graph.graph):
+                if roller.has_matmul_with_rdim(graph_info.graph):
                     can_roll_graphs = False
                     break
 
             if not can_roll_graphs:
                 # Can't roll any graphs for this rdim, but still need to add the spec
-                env.config_spec.reduction_loop_specs.append(
+                env.config_spec.reduction_loops.append(
                     ReductionLoopSpec(
+                        block_id=rdim.block_id,
                         size_hint=rdim.size_hint(),
-                        allow_loop=False,  # Don't allow loop since we can't roll
                     )
                 )
                 first = False

--- a/helion/_compiler/inductor_lowering.py
+++ b/helion/_compiler/inductor_lowering.py
@@ -6,6 +6,7 @@ import dataclasses
 import functools
 from operator import getitem
 from typing import TYPE_CHECKING
+from typing import Callable
 from typing import ContextManager
 from typing import NamedTuple
 
@@ -148,21 +149,33 @@ def prepare_node_lowering(
             # pyre-ignore[6]
             *map_arg((node.args, node.kwargs), convert_arg),
         )
-        result.realize()
-    if not isinstance(result, TensorBox) or not isinstance(result.data, StorageBox):
-        raise InductorLoweringError(
-            f"Lowering {node.target} returned type(result), expected TensorBox(StorageBox(...)): {result}"
-        )
-    if not isinstance(buffer := result.data.data, ComputedBuffer):
-        raise InductorLoweringError(
-            f"Lowering {node.target} returned buffer type {type(buffer)}, expected ComputedBuffer: {buffer}"
-        )
+        if not isinstance(result, tuple):
+            result = (result,)
+        buffer_name_to_output_index = {}
+        for i, r in enumerate(result):
+            r.realize()
+            if not isinstance(r, TensorBox) or not isinstance(r.data, StorageBox):
+                raise InductorLoweringError(
+                    f"Lowering {node.target} returned {type(r)}, expected TensorBox(StorageBox(...)): {r}"
+                )
+            if not isinstance(buffer := r.data.data, ComputedBuffer):
+                raise InductorLoweringError(
+                    f"Lowering {node.target} returned buffer type {type(buffer)}, expected ComputedBuffer: {buffer}"
+                )
+            buffer_name_to_output_index[buffer.get_name()] = i
 
     new_buffers = graph_lowering.buffers[prior_buffers:]
-    assert new_buffers[-1] is buffer
+    assert buffer in new_buffers  # pyre-ignore[61]
     nodes = []
     extra_input_names = []
     new_node: torch.fx.Node
+
+    # Explicitly track the mapping from node to Inductor buffer name.
+    # First, map the original input nodes to their names.
+    node_to_buf_name_mapping: dict[torch.fx.Node, str] = dict(
+        zip(node._input_nodes, input_names, strict=True)
+    )
+
     for i, buffer in enumerate(new_buffers):
         if not isinstance(buffer, ComputedBuffer) or not isinstance(
             buffer.data, (Pointwise, Reduction)
@@ -176,28 +189,48 @@ def prepare_node_lowering(
                 new_node.kwargs = {**new_node.kwargs, "_extra_args": [*nodes]}
         else:
             new_node = create_extra_node(node, buffer, [*node._input_nodes, *nodes])
+
+        # Store output index if this buffer corresponds to an output
+        if buffer.get_name() in buffer_name_to_output_index:
+            new_node.meta["output_index"] = buffer_name_to_output_index[
+                buffer.get_name()
+            ]
+
         lowering_cls = (
             PointwiseLowering
             if isinstance(buffer.data, Pointwise)
             else ReductionLowering
         )
         buffer.freeze_layout()
+
+        current_input_nodes = new_node._input_nodes
+        current_input_names = []
+        for inp_node in current_input_nodes:
+            current_input_names.append(node_to_buf_name_mapping[inp_node])
+
         used_input_names = strip_unused_inputs(
             new_node,
             buffer.get_read_names(),
-            dict(
-                zip(
-                    node.all_input_nodes,
-                    [*input_names, *extra_input_names],
-                    strict=True,
-                )
-            ),
+            dict(zip(current_input_nodes, current_input_names, strict=True)),
         )
         new_node.meta["lowering"] = lowering = lowering_cls(buffer, used_input_names)
+        new_node.meta["orig_node"] = node
         if isinstance(lowering, ReductionLowering):
             lowering.add_input_mask(new_node)
         nodes.append(new_node)
         extra_input_names.append(buffer.get_name())
+
+        # Add this node to our mapping for future nodes to reference
+        node_to_buf_name_mapping[new_node] = buffer.get_name()
+
+    # After all nodes are created, build the output_nodes mapping for multi-output operations
+    if len(result) > 1 and nodes:
+        last_node = nodes[-1]  # The last node is the main node
+        output_nodes = {}
+        for n in nodes:
+            if "output_index" in n.meta:
+                output_nodes[n.meta["output_index"]] = n.name
+        last_node.meta["output_nodes"] = output_nodes
 
 
 def strip_unused_inputs(
@@ -395,7 +428,6 @@ class ReductionLowering(InductorLowering):
             raise NotImplementedError("multiple reduction dimensions")
         reduction_var = reduction_ranges[0]
         assert isinstance(reduction_var, sympy.Symbol)
-
         block_index = TileStrategy.get_block_index(reduction_var)
         assert block_index is not None
         self.block_index: int = block_index
@@ -447,14 +479,23 @@ class ReductionLowering(InductorLowering):
             strategy = BlockReductionStrategy(state, self.block_index)
 
         inputs = self.input_fake_tensors(node)
-        if len(inputs) != 1:
-            # TODO(jansel): combine multiple inputs into a single fake value
-            raise NotImplementedError("reductions with >1 input")
+
+        repr_input = None
+        if len(inputs) == 1:
+            repr_input = inputs[0]
+        else:
+            if node.meta["orig_node"].target == torch.ops.aten.var_mean.correction:
+                assert len(inputs) == 2
+                # `inputs[0]` is the original input tensor to var_mean
+                repr_input = inputs[0]
+            else:
+                # TODO(jansel): combine multiple inputs into a single fake value
+                raise NotImplementedError("reductions with >1 input")
 
         # TODO(jansel): find a better way to get dim
         (dim,) = [
             i
-            for i, v in enumerate(inputs[0].shape)
+            for i, v in enumerate(repr_input.shape)
             if TileStrategy.get_block_index(v) == self.block_index
         ]
 
@@ -463,7 +504,7 @@ class ReductionLowering(InductorLowering):
             output_name,
             reduction.reduction_type,
             dim,
-            inputs[0],
+            repr_input,
             node.meta["val"],
         )
 
@@ -806,6 +847,14 @@ class GenerateASTFromInductor(DefaultHandler):
         name = self.cg.lift(
             expr_from_string(self.cg.device_function.user_sympy_expr(expr))
         ).id
+
+        # If the lifted symbol refers to a `tl.constexpr` kernel
+        # argument (for example a tile/block size constant such as
+        # `_BLOCK_SIZE_1`) the resulting Triton value is not a tensor
+        # and therefore does not expose a `.to` method.
+        if name in self.cg.device_function._constexpr_args:
+            return name
+
         return f"{name}.to({triton_type(dtype)})"
 
 
@@ -821,11 +870,57 @@ class GraphInterpreter(Interpreter):
         super().__init__(_LazyGraphModule({}, graph), garbage_collect_values=False)
         self.cg = cg
 
+    def _collect_multi_outputs(
+        self, node: Node, last_node_result: object
+    ) -> tuple[object, ...]:
+        """
+        Collect outputs for multi-output operations using metadata.
+        """
+        # Check if this operation has multiple outputs using the new metadata
+        assert "output_nodes" in node.meta
+        output_nodes = node.meta["output_nodes"]
+        outputs = [None] * len(output_nodes)
+        all_nodes = {n.name: n for n in self.module.graph.nodes}  # pyre-ignore[16]
+
+        for idx, node_name in output_nodes.items():
+            if node_name == node.name:
+                # This is the last node
+                outputs[idx] = last_node_result  # pyre-ignore[6]
+            else:
+                # This is an extra node - get its result from env
+                if node_name in all_nodes:
+                    extra_node = all_nodes[node_name]
+                    if extra_node in self.env:
+                        outputs[idx] = self.env[extra_node]
+
+        # Ensure all outputs are found and are ast.Name nodes
+        final_outputs = []
+        for i, result in enumerate(outputs):
+            assert result is not None
+            if not isinstance(result, ast.Name):
+                var_name = self.cg.device_function.new_var(f"{node.name}_output{i}")
+                self.cg.add_statement(
+                    statement_from_string(f"{var_name} = result", result=result)
+                )
+                result = create(ast.Name, id=var_name, ctx=ast.Load())
+            final_outputs.append(result)
+
+        return tuple(final_outputs)
+
     def run_node(self, n: Node) -> object:
         if n.op == "call_function":
             with self._set_current_node(n), n.meta["location"]:
                 lowering: Lowering = n.meta["lowering"]
                 result = lowering.codegen(self, n)
+                n.meta["codegen"] = result
+
+                # Generic handling for operations with multiple outputs
+                if n.kwargs.get("_extra_args"):
+                    # Check if this node has getitem users, indicating multiple outputs
+                    getitem_users = [user for user in n.users if user.target == getitem]
+                    if len(getitem_users) > 0:
+                        return self._collect_multi_outputs(n, result)
+
                 if result is None:
                     return None
                 if not isinstance(result, ast.AST):

--- a/helion/_compiler/inductor_lowering.py
+++ b/helion/_compiler/inductor_lowering.py
@@ -428,6 +428,7 @@ class ReductionLowering(InductorLowering):
             raise NotImplementedError("multiple reduction dimensions")
         reduction_var = reduction_ranges[0]
         assert isinstance(reduction_var, sympy.Symbol)
+
         block_index = TileStrategy.get_block_index(reduction_var)
         assert block_index is not None
         self.block_index: int = block_index

--- a/helion/_compiler/inductor_lowering_extra.py
+++ b/helion/_compiler/inductor_lowering_extra.py
@@ -1,0 +1,172 @@
+from __future__ import annotations
+
+import contextlib
+import functools
+from typing import Any
+from typing import Callable
+from typing import Generator
+
+import torch
+from torch._inductor.lowering import to_dtype
+from torch._prims_common import ELEMENTWISE_TYPE_PROMOTION_KIND
+
+inductor_lowering_dispatch: dict[  # pyre-ignore[5]
+    Callable[..., Any] | str, Callable[..., Any]
+] = {}
+
+
+@contextlib.contextmanager
+def patch_inductor_lowerings() -> Generator[  # pyre-ignore[3]
+    None, Any, Any
+]:
+    """Context manager to temporarily patch the inductor lowering table.
+
+    This is useful for overwriting specific Inductor lowerings without
+    affecting the global state, especially in cases where Helion
+    is missing support for a specific lowering.
+    """
+    original_lowerings = torch._inductor.lowering.lowerings.copy()
+    try:
+        torch._inductor.lowering.lowerings.update(inductor_lowering_dispatch)
+        yield
+    finally:
+        torch._inductor.lowering.lowerings = original_lowerings
+
+
+def _register_inductor_lowering(
+    aten_fn: object,
+    decomp_fn: object,
+    broadcast: bool,
+    type_promotion_kind: ELEMENTWISE_TYPE_PROMOTION_KIND | None,
+    convert_input_to_bool: bool,
+    lowering_dict: dict[object, Callable[..., object]],
+) -> Callable[..., object]:
+    from torch._inductor.lowering import fallbacks
+    from torch._inductor.lowering import get_overloads
+    from torch._inductor.lowering import in_namespace
+    from torch._inductor.lowering import transform_args
+    from torch._inductor.lowering import validate_ir
+
+    @functools.wraps(decomp_fn)  # pyre-ignore[6]
+    def wrapped(*args: Any, **kwargs: Any) -> object:
+        args = list(args)  # pyre-ignore[9]
+        kwargs = dict(kwargs)
+        unpacked = False
+        if len(args) == 1 and isinstance(args[0], (list, tuple)):
+            unpacked = True
+            args = list(args[0])  # pyre-ignore[9]
+
+        if not all(
+            (fn in fallbacks or in_namespace(fn, "_c10d_functional"))
+            for fn in aten_fn  # pyre-ignore[16]
+        ):
+            # explicitly assert for "out=" ops for better error messages
+            assert not any(x == "out" for x in kwargs), "out= ops aren't yet supported"
+
+        args, kwargs = transform_args(  # pyre-ignore[9]
+            args,  # pyre-ignore[6]
+            kwargs,
+            broadcast,
+            type_promotion_kind,
+            convert_input_to_bool,
+        )
+
+        if unpacked:
+            args = [args]  # pyre-ignore[9]
+
+        out = decomp_fn(*args, **kwargs)  # pyre-ignore[29]
+        validate_ir(out)
+
+        return out
+
+    aten_fn = get_overloads(aten_fn)
+
+    lowering_dict.update(dict.fromkeys(aten_fn, wrapped))
+    return wrapped
+
+
+# TODO(yf225): Switch to use upstream torch._inductor.lowering.register_lowering() after PyTorch 2.8 is released.
+def register_inductor_lowering(
+    aten_fn: object,
+    broadcast: bool = False,
+    type_promotion_kind: ELEMENTWISE_TYPE_PROMOTION_KIND
+    | None = ELEMENTWISE_TYPE_PROMOTION_KIND.DEFAULT,
+    convert_input_to_bool: bool = False,
+    lowering_dict: dict[  # pyre-ignore[2]
+        Any, Callable[..., Any]
+    ] = inductor_lowering_dispatch,
+) -> Callable[..., object]:
+    return functools.partial(
+        _register_inductor_lowering,
+        aten_fn,
+        broadcast=broadcast,
+        type_promotion_kind=type_promotion_kind,
+        convert_input_to_bool=convert_input_to_bool,
+        lowering_dict=lowering_dict,
+    )
+
+
+def var_mean_helper_(
+    x: torch._inductor.ir.TensorBox,
+    *,
+    axis: list[int] | None,
+    correction: float | None,
+    keepdim: bool,
+    return_mean: bool,
+) -> torch._inductor.ir.TensorBox:
+    from torch._inductor.lowering import var_mean_sum_
+    from torch._prims_common import get_computation_dtype
+
+    out_dtype = x.get_dtype()
+    compute_dtype = get_computation_dtype(out_dtype)
+    x = to_dtype(x, compute_dtype, copy=False)
+
+    kwargs = {
+        "x": x,
+        "axis": axis,
+        "correction": correction,
+        "keepdim": keepdim,
+        "return_mean": return_mean,
+    }
+    # TODO(yf225): support Welford reduction in Helion, then switch back to use Inductor `var_mean_helper_()`.
+    output = var_mean_sum_(**kwargs)
+    output = tuple(to_dtype(o, out_dtype, copy=False) for o in output)
+    return output[0] if not return_mean else output
+
+
+@register_inductor_lowering(
+    [torch.ops.aten.var.correction], lowering_dict=inductor_lowering_dispatch
+)
+def var_(
+    x: torch._inductor.ir.TensorBox,
+    axis: list[int] | None = None,
+    *,
+    correction: float | None = None,
+    keepdim: bool = False,
+) -> torch._inductor.ir.TensorBox:
+    return var_mean_helper_(
+        x,
+        axis=axis,
+        correction=correction,
+        keepdim=keepdim,
+        return_mean=False,
+    )
+
+
+@register_inductor_lowering(  # pyre-ignore[56]
+    torch.ops.aten.var_mean.correction, lowering_dict=inductor_lowering_dispatch
+)
+def var_mean(
+    x: torch._inductor.ir.TensorBox,
+    axis: list[int] | None = None,
+    *,
+    correction: float | None = None,
+    keepdim: bool = False,
+) -> torch._inductor.ir.TensorBox:
+    return var_mean_helper_(
+        x,
+        axis=axis,
+        correction=correction,
+        keepdim=keepdim,
+        return_mean=True,
+    )

--- a/helion/_compiler/roll_reduction.py
+++ b/helion/_compiler/roll_reduction.py
@@ -114,7 +114,7 @@ class ReductionRoller:
                 if isinstance(item, torch.Tensor):
                     for size in item.size():
                         block_idx = TileStrategy.get_block_index(size)
-                        num_rdims += block_idx == self.rdim.block_size_idx
+                        num_rdims += block_idx == self.rdim.block_id
             if num_rdims > 1:
                 raise NotImplementedError(
                     "multiple reduction dims of same size not supported"
@@ -264,7 +264,7 @@ class ReductionRoller:
                 if isinstance(val, torch.Tensor):
                     for size in val.size():
                         block_idx = TileStrategy.get_block_index(size)
-                        if block_idx == self.rdim.block_size_idx:
+                        if block_idx == self.rdim.block_id:
                             return True
             return False
 

--- a/helion/_compiler/roll_reduction.py
+++ b/helion/_compiler/roll_reduction.py
@@ -108,10 +108,20 @@ class ReductionRoller:
                 raise NotImplementedError(
                     "multiple reduction dims of same size not supported"
                 )
+        elif isinstance(val, (tuple, list)):
+            # Some operations like var_mean return tuples of tensors
+            for item in val:
+                if isinstance(item, torch.Tensor):
+                    for size in item.size():
+                        block_idx = TileStrategy.get_block_index(size)
+                        num_rdims += block_idx == self.rdim.block_size_idx
+            if num_rdims > 1:
+                raise NotImplementedError(
+                    "multiple reduction dims of same size not supported"
+                )
         else:
-            raise NotImplementedError(
-                f"Unsupported value type {type(val)} from {node.target}"
-            )
+            # For non-tensor values (e.g., scalars), they don't use reduction dims
+            num_rdims = 0
 
         return num_rdims > 0
 
@@ -236,6 +246,29 @@ class ReductionRoller:
             placeholder.meta.update(node.meta)
         self.inner_args.append(outer_node)
         return placeholder
+
+    def has_matmul_with_rdim(self, graph: torch.fx.Graph) -> bool:
+        """Check if a graph contains matmul operations with rdim inputs."""
+
+        def is_matmul_with_rdim(node: torch.fx.Node) -> bool:
+            """Check if a node is a matmul operation with rdim inputs."""
+            if node.op != "call_function":
+                return False
+
+            if node.target != torch.ops.aten.mm.default:
+                return False
+
+            # Check if any inputs to matmul have rdim
+            for input_node in node.all_input_nodes:
+                val = input_node.meta.get("val", None)
+                if isinstance(val, torch.Tensor):
+                    for size in val.size():
+                        block_idx = TileStrategy.get_block_index(size)
+                        if block_idx == self.rdim.block_size_idx:
+                            return True
+            return False
+
+        return any(is_matmul_with_rdim(node) for node in graph.nodes)
 
     def process(self, graph: torch.fx.Graph) -> torch.fx.Graph:
         for node in graph.nodes:

--- a/helion/_compiler/type_propagation.py
+++ b/helion/_compiler/type_propagation.py
@@ -1042,31 +1042,31 @@ class GridIndexType(SymIntType):
 class ReductionDimType(SymIntType):
     """Type for reduction dimensions allocated via register_reduction_dim"""
 
-    block_size_idx: int
+    block_id: int
 
-    def __init__(self, origin: Origin, block_size_idx: int) -> None:
+    def __init__(self, origin: Origin, block_id: int) -> None:
         from .._compiler.compile_environment import CompileEnvironment
 
         env = CompileEnvironment.current()
-        super().__init__(origin, env.block_sizes[block_size_idx].var)
-        self.block_size_idx = block_size_idx
+        super().__init__(origin, env.block_sizes[block_id].var)
+        self.block_id = block_id
 
     def __str__(self) -> str:
-        return f"{type(self).__name__}({self.block_size_idx})"
+        return f"{type(self).__name__}({self.block_id})"
 
     def proxy(self) -> torch.SymInt:
         """Return the RDIM variable when used in expressions"""
         from .._compiler.compile_environment import CompileEnvironment
 
         env = CompileEnvironment.current()
-        return env.block_sizes[self.block_size_idx].var
+        return env.block_sizes[self.block_id].var
 
     def merge(self, other: TypeInfo) -> TypeInfo:
         if isinstance(other, ReductionDimType):
-            if self.block_size_idx == other.block_size_idx:
+            if self.block_id == other.block_id:
                 return self
             return UnknownType(
-                debug_msg=f"ReductionDimType mismatch in control flow: {self.block_size_idx} and {other.block_size_idx}",
+                debug_msg=f"ReductionDimType mismatch in control flow: {self.block_id} and {other.block_id}",
                 origin=other.origin,
             )
         return super().merge(other)

--- a/helion/_compiler/type_propagation.py
+++ b/helion/_compiler/type_propagation.py
@@ -1039,6 +1039,39 @@ class GridIndexType(SymIntType):
         return super().merge(other)
 
 
+class ReductionDimType(SymIntType):
+    """Type for reduction dimensions allocated via register_reduction_dim"""
+
+    block_size_idx: int
+
+    def __init__(self, origin: Origin, block_size_idx: int) -> None:
+        from .._compiler.compile_environment import CompileEnvironment
+
+        env = CompileEnvironment.current()
+        super().__init__(origin, env.block_sizes[block_size_idx].var)
+        self.block_size_idx = block_size_idx
+
+    def __str__(self) -> str:
+        return f"{type(self).__name__}({self.block_size_idx})"
+
+    def proxy(self) -> torch.SymInt:
+        """Return the RDIM variable when used in expressions"""
+        from .._compiler.compile_environment import CompileEnvironment
+
+        env = CompileEnvironment.current()
+        return env.block_sizes[self.block_size_idx].var
+
+    def merge(self, other: TypeInfo) -> TypeInfo:
+        if isinstance(other, ReductionDimType):
+            if self.block_size_idx == other.block_size_idx:
+                return self
+            return UnknownType(
+                debug_msg=f"ReductionDimType mismatch in control flow: {self.block_size_idx} and {other.block_size_idx}",
+                origin=other.origin,
+            )
+        return super().merge(other)
+
+
 class IterType(TypeInfo):
     inner: TypeInfo
 

--- a/helion/language/__init__.py
+++ b/helion/language/__init__.py
@@ -7,6 +7,7 @@ from .creation_ops import zeros as zeros
 from .loops import Tile as Tile
 from .loops import grid as grid
 from .loops import register_block_size as register_block_size
+from .loops import register_reduction_dim as register_reduction_dim
 from .loops import tile as tile
 from .memory_ops import atomic_add as atomic_add
 from .memory_ops import load as load

--- a/helion/language/loops.py
+++ b/helion/language/loops.py
@@ -454,7 +454,7 @@ def _(sizes: TypeInfo, *, origin: Origin) -> TypeInfo:
     env = CompileEnvironment.current()
 
     rdim = env.allocate_reduction_dimension(proxy_sizes)
-    return ReductionDimType(origin, rdim.block_size_idx)
+    return ReductionDimType(origin, rdim.block_id)
 
 
 @_decorators.codegen(register_reduction_dim)

--- a/helion/language/loops.py
+++ b/helion/language/loops.py
@@ -38,7 +38,7 @@ if TYPE_CHECKING:
     from .._compiler.inductor_lowering import CodegenState
 
 
-__all__ = ["Tile", "grid", "register_block_size", "tile"]
+__all__ = ["Tile", "grid", "register_block_size", "register_reduction_dim", "tile"]
 Tile = TileIndexProxy
 
 
@@ -403,3 +403,67 @@ def _(
     loop_spec.min_size = assert_integer_power_of_two(max(1, min_proxy))
     loop_spec.max_size = next_power_of_2(env.size_hint(max_proxy))
     return result
+
+
+@_decorators.api(is_device_only=False, cache_type=True, tiles_as_sizes=True)
+def register_reduction_dim(
+    size: int,
+) -> torch.SymInt:
+    """
+    Explicitly register a reduction dimension that should be used for reduction operations.
+
+    This is useful when you need to allocate a dimension for reduction that isn't
+    automatically inferred from a slice operation. The registered dimension can be
+    used for allocations and operations that require knowing the reduction size upfront.
+
+    :param size: An integer representing the reduction dimension size.
+    :return: A SymInt object representing the reduction dimension size.
+    """
+    raise exc.NotInsideKernel
+
+
+@_decorators.register_fake(register_reduction_dim)
+def _(size: int) -> torch.SymInt:
+    """Fake implementation that returns the registered reduction dimension size(s)"""
+    from .._compiler.compile_environment import CompileEnvironment
+
+    env = CompileEnvironment.current()
+
+    rdim = env.allocate_reduction_dimension(size)
+    return rdim.var
+
+
+@_decorators.type_propagation(register_reduction_dim)
+def _(sizes: TypeInfo, *, origin: Origin) -> TypeInfo:
+    from .._compiler.compile_environment import CompileEnvironment
+    from .._compiler.type_propagation import ReductionDimType
+
+    try:
+        proxy_sizes = sizes.proxy()
+        if not isinstance(proxy_sizes, int | torch.SymInt):
+            raise NotImplementedError
+    except NotImplementedError:
+        raise exc.TypePropagationError(
+            UnknownType(
+                origin,
+                f"register_reduction_dim() expected int or list[int], got {sizes!s}",
+                chained_from=sizes,
+            )
+        ) from None
+
+    env = CompileEnvironment.current()
+
+    rdim = env.allocate_reduction_dimension(proxy_sizes)
+    return ReductionDimType(origin, rdim.block_size_idx)
+
+
+@_decorators.codegen(register_reduction_dim)
+def _(state: CodegenState) -> ast.AST:
+    """Generate code for register_reduction_dim - return the size expression"""
+    from .._compiler.type_propagation import ReductionDimType
+
+    current_node = ExtendedAST.current()[-1]
+    type_info = current_node._type_info
+
+    assert isinstance(type_info, ReductionDimType)
+    return current_node.args[0]  # pyre-ignore[16]

--- a/helion/runtime/kernel.py
+++ b/helion/runtime/kernel.py
@@ -27,6 +27,7 @@ from .._compiler.ast_extension import unparse
 from .._compiler.compile_environment import CompileEnvironment
 from .._compiler.generate_ast import generate_ast
 from .._compiler.host_function import HostFunction
+from .._compiler.inductor_lowering_extra import patch_inductor_lowerings
 from .._compiler.output_header import assert_no_conflicts
 from .._compiler.output_header import get_needed_imports
 from .._compiler.variable_origin import ArgumentOrigin
@@ -280,7 +281,10 @@ class BoundKernel:
                     constexpr_args[name] = arg
                 else:
                     self.fake_args.append(self.env.to_fake(arg, ArgumentOrigin(name)))
-            with _maybe_skip_dtype_check_in_meta_registrations():
+            with (
+                _maybe_skip_dtype_check_in_meta_registrations(),
+                patch_inductor_lowerings(),
+            ):
                 self.host_function: HostFunction = HostFunction(
                     self.kernel.fn, self.fake_args, constexpr_args
                 )

--- a/test/test_examples.py
+++ b/test/test_examples.py
@@ -23,10 +23,16 @@ def run_example(
     expected: torch.Tensor,
     fn_name: str | None = None,
     skip_accuracy=False,
+    static_shapes=None,
     **kwargs: object,
 ) -> str:
+    kernel_fn = getattr(import_path(examples_dir / f"{name}.py"), fn_name or name)
+    if static_shapes is not None:
+        assert static_shapes in (True, False)
+        kernel_fn.settings.static_shapes = static_shapes
+
     code, result = code_and_output(
-        getattr(import_path(examples_dir / f"{name}.py"), fn_name or name),
+        kernel_fn,
         args,
         **kwargs,
     )
@@ -144,6 +150,197 @@ def _matmul_make_precompiler(x: torch.Tensor, y: torch.Tensor):
     _BLOCK_SIZE_2 = 16
     from helion.runtime.precompile_shim import make_precompiler
     return make_precompiler(_matmul_kernel)(x, y, out, _BLOCK_SIZE_0, _BLOCK_SIZE_1, _BLOCK_SIZE_2, num_warps=4, num_stages=3)""",
+        )
+
+    def test_matmul_layernorm_static_shapes(self):
+        args = (
+            torch.randn([128, 256], device=DEVICE, dtype=torch.float32),
+            torch.randn([256, 400], device=DEVICE, dtype=torch.float32),
+            torch.randn([400], device=DEVICE, dtype=torch.float32),
+            torch.randn([400], device=DEVICE, dtype=torch.float32),
+        )
+        self.assertExpectedInline(
+            run_example(
+                "matmul_layernorm",
+                args,
+                torch.nn.functional.layer_norm(
+                    (args[0] @ args[1]),
+                    normalized_shape=(400,),
+                    weight=args[2],
+                    bias=args[3],
+                ),
+                block_sizes=[16, 16],
+                l2_grouping=4,
+                static_shapes=True,
+            ),
+            """\
+from __future__ import annotations
+
+import torch
+import triton
+import triton.language as tl
+from torch._inductor.runtime.triton_compat import libdevice
+
+@triton.jit
+def _matmul_layernorm_kernel(x, y, weight, bias, out, out_stride_0, _BLOCK_SIZE_1: tl.constexpr, _RDIM_SIZE_0: tl.constexpr, _BLOCK_SIZE_2: tl.constexpr):
+    pid_0 = tl.program_id(0)
+    offset_1 = pid_0 * _BLOCK_SIZE_1
+    indices_1 = (offset_1 + tl.arange(0, _BLOCK_SIZE_1)).to(tl.int32)
+    indices_0 = tl.arange(0, _RDIM_SIZE_0).to(tl.int32)
+    mask_0 = indices_0 < 400
+    acc = tl.full([_BLOCK_SIZE_1, _RDIM_SIZE_0], 0.0, tl.float32)
+    for offset_2 in range(0, 256, _BLOCK_SIZE_2):
+        indices_2 = offset_2 + tl.arange(0, _BLOCK_SIZE_2).to(tl.int32)
+        acc_copy = acc
+        load = tl.load(x + (indices_1[:, None] * 256 + indices_2[None, :] * 1), None)
+        load_1 = tl.load(y + (indices_2[:, None] * 400 + indices_0[None, :] * 1), mask_0[None, :], other=0)
+        mm = tl.dot(load, load_1, input_precision='tf32')
+        acc = acc_copy + mm
+    _mask_to = tl.where(tl.broadcast_to(mask_0[None, :], [_BLOCK_SIZE_1, _RDIM_SIZE_0]), acc, 0)
+    var_mean_extra = tl.reshape(tl.sum(_mask_to, 1), [_BLOCK_SIZE_1, 1])
+    v_1 = 400
+    v_2 = var_mean_extra / v_1.to(tl.float32)
+    v_3 = _mask_to - v_2
+    v_4 = v_3 * v_3
+    var_mean_extra_2 = tl.reshape(tl.sum(v_4, 1), [_BLOCK_SIZE_1, 1])
+    v_5 = 400
+    v_6 = var_mean_extra_2 / v_5.to(tl.float32)
+    v_7 = acc - v_2
+    v_8 = 1e-05
+    v_9 = v_6 + v_8
+    v_10 = libdevice.rsqrt(v_9)
+    v_11 = v_7 * v_10
+    load_2 = tl.load(weight + indices_0 * 1, mask_0, other=0)
+    v_12 = load_2[None, :]
+    v_13 = v_11 * v_12
+    load_3 = tl.load(bias + indices_0 * 1, mask_0, other=0)
+    v_14 = load_3[None, :]
+    v_15 = v_13 + v_14
+    tl.store(out + (indices_1[:, None] * out_stride_0 + indices_0[None, :] * 1), v_15, mask_0[None, :])
+
+def matmul_layernorm(x: torch.Tensor, y: torch.Tensor, weight: torch.Tensor, bias: torch.Tensor):
+    m, k = x.size()
+    k2 = y.size(0)
+    n = y.size(1)
+    assert k == k2, f'size mismatch {k} != {k2}'
+    assert weight.size(0) == n, f'weight size mismatch {weight.size(0)} != {n}'
+    assert bias.size(0) == n, f'bias size mismatch {bias.size(0)} != {n}'
+    out = torch.empty([m, n], dtype=torch.promote_types(x.dtype, y.dtype), device=x.device)
+    _BLOCK_SIZE_1 = 16
+    _RDIM_SIZE_0 = 512
+    _BLOCK_SIZE_2 = 16
+    _matmul_layernorm_kernel[triton.cdiv(128, _BLOCK_SIZE_1),](x, y, weight, bias, out, out.stride(0), _BLOCK_SIZE_1, _RDIM_SIZE_0, _BLOCK_SIZE_2, num_warps=4, num_stages=3)
+    return out
+
+def _matmul_layernorm_make_precompiler(x: torch.Tensor, y: torch.Tensor, weight: torch.Tensor, bias: torch.Tensor):
+    m, k = x.size()
+    k2 = y.size(0)
+    n = y.size(1)
+    assert k == k2, f'size mismatch {k} != {k2}'
+    assert weight.size(0) == n, f'weight size mismatch {weight.size(0)} != {n}'
+    assert bias.size(0) == n, f'bias size mismatch {bias.size(0)} != {n}'
+    out = torch.empty([m, n], dtype=torch.promote_types(x.dtype, y.dtype), device=x.device)
+    _BLOCK_SIZE_1 = 16
+    _RDIM_SIZE_0 = 512
+    _BLOCK_SIZE_2 = 16
+    from helion.runtime.precompile_shim import make_precompiler
+    return make_precompiler(_matmul_layernorm_kernel)(x, y, weight, bias, out, out.stride(0), _BLOCK_SIZE_1, _RDIM_SIZE_0, _BLOCK_SIZE_2, num_warps=4, num_stages=3)""",
+        )
+
+    def test_matmul_layernorm_dynamic_shapes(self):
+        args = (
+            torch.randn([128, 256], device=DEVICE, dtype=torch.float32),
+            torch.randn([256, 400], device=DEVICE, dtype=torch.float32),
+            torch.randn([400], device=DEVICE, dtype=torch.float32),
+            torch.randn([400], device=DEVICE, dtype=torch.float32),
+        )
+        self.assertExpectedInline(
+            run_example(
+                "matmul_layernorm",
+                args,
+                torch.nn.functional.layer_norm(
+                    (args[0] @ args[1]),
+                    normalized_shape=(400,),
+                    weight=args[2],
+                    bias=args[3],
+                ),
+                block_sizes=[16, 16],
+                l2_grouping=4,
+                static_shapes=False,
+            ),
+            """\
+from __future__ import annotations
+
+import torch
+import triton
+import triton.language as tl
+from torch._inductor.runtime.triton_compat import libdevice
+
+@triton.jit
+def _matmul_layernorm_kernel(bias, x, y, weight, out, bias_size_0, bias_stride_0, out_stride_0, out_stride_1, weight_stride_0, x_stride_0, x_stride_1, y_stride_0, y_stride_1, m, k, _BLOCK_SIZE_1: tl.constexpr, _RDIM_SIZE_0: tl.constexpr, _BLOCK_SIZE_2: tl.constexpr):
+    pid_0 = tl.program_id(0)
+    offset_1 = pid_0 * _BLOCK_SIZE_1
+    indices_1 = (offset_1 + tl.arange(0, _BLOCK_SIZE_1)).to(tl.int32)
+    mask_1 = indices_1 < m
+    indices_0 = tl.arange(0, _RDIM_SIZE_0).to(tl.int32)
+    mask_0 = indices_0 < bias_size_0
+    acc = tl.full([_BLOCK_SIZE_1, _RDIM_SIZE_0], 0.0, tl.float32)
+    for offset_2 in range(0, k.to(tl.int32), _BLOCK_SIZE_2):
+        indices_2 = offset_2 + tl.arange(0, _BLOCK_SIZE_2).to(tl.int32)
+        mask_2 = indices_2 < k
+        acc_copy = acc
+        load = tl.load(x + (indices_1[:, None] * x_stride_0 + indices_2[None, :] * x_stride_1), mask_1[:, None] & mask_2[None, :], other=0)
+        load_1 = tl.load(y + (indices_2[:, None] * y_stride_0 + indices_0[None, :] * y_stride_1), mask_2[:, None] & mask_0[None, :], other=0)
+        mm = tl.dot(load, load_1, input_precision='tf32')
+        acc = acc_copy + mm
+    _mask_to = tl.where(mask_1[:, None] & mask_0[None, :], acc, 0)
+    var_mean_extra = tl.reshape(tl.sum(_mask_to, 1), [_BLOCK_SIZE_1, 1])
+    v_1 = var_mean_extra / bias_size_0.to(tl.float32)
+    _mask_to_1 = tl.where(tl.broadcast_to(mask_1[:, None], [_BLOCK_SIZE_1, 1]), v_1, 0)
+    v_2 = _mask_to - _mask_to_1
+    v_3 = v_2 * v_2
+    var_mean_extra_2 = tl.reshape(tl.sum(v_3, 1), [_BLOCK_SIZE_1, 1])
+    v_4 = var_mean_extra_2 / bias_size_0.to(tl.float32)
+    v_5 = acc - v_1
+    v_6 = 1e-05
+    v_7 = v_4 + v_6
+    v_8 = libdevice.rsqrt(v_7)
+    v_9 = v_5 * v_8
+    load_2 = tl.load(weight + indices_0 * weight_stride_0, mask_0, other=0)
+    v_10 = load_2[None, :]
+    v_11 = v_9 * v_10
+    load_3 = tl.load(bias + indices_0 * bias_stride_0, mask_0, other=0)
+    v_12 = load_3[None, :]
+    v_13 = v_11 + v_12
+    tl.store(out + (indices_1[:, None] * out_stride_0 + indices_0[None, :] * out_stride_1), v_13, mask_1[:, None] & mask_0[None, :])
+
+def matmul_layernorm(x: torch.Tensor, y: torch.Tensor, weight: torch.Tensor, bias: torch.Tensor):
+    m, k = x.size()
+    k2 = y.size(0)
+    n = y.size(1)
+    assert k == k2, f'size mismatch {k} != {k2}'
+    assert weight.size(0) == n, f'weight size mismatch {weight.size(0)} != {n}'
+    assert bias.size(0) == n, f'bias size mismatch {bias.size(0)} != {n}'
+    out = torch.empty([m, n], dtype=torch.promote_types(x.dtype, y.dtype), device=x.device)
+    _BLOCK_SIZE_1 = 16
+    _RDIM_SIZE_0 = triton.next_power_of_2(bias.size(0))
+    _BLOCK_SIZE_2 = 16
+    _matmul_layernorm_kernel[triton.cdiv(m, _BLOCK_SIZE_1),](bias, x, y, weight, out, bias.size(0), bias.stride(0), out.stride(0), out.stride(1), weight.stride(0), x.stride(0), x.stride(1), y.stride(0), y.stride(1), m, k, _BLOCK_SIZE_1, _RDIM_SIZE_0, _BLOCK_SIZE_2, num_warps=4, num_stages=3)
+    return out
+
+def _matmul_layernorm_make_precompiler(x: torch.Tensor, y: torch.Tensor, weight: torch.Tensor, bias: torch.Tensor):
+    m, k = x.size()
+    k2 = y.size(0)
+    n = y.size(1)
+    assert k == k2, f'size mismatch {k} != {k2}'
+    assert weight.size(0) == n, f'weight size mismatch {weight.size(0)} != {n}'
+    assert bias.size(0) == n, f'bias size mismatch {bias.size(0)} != {n}'
+    out = torch.empty([m, n], dtype=torch.promote_types(x.dtype, y.dtype), device=x.device)
+    _BLOCK_SIZE_1 = 16
+    _RDIM_SIZE_0 = triton.next_power_of_2(bias.size(0))
+    _BLOCK_SIZE_2 = 16
+    from helion.runtime.precompile_shim import make_precompiler
+    return make_precompiler(_matmul_layernorm_kernel)(bias, x, y, weight, out, bias.size(0), bias.stride(0), out.stride(0), out.stride(1), weight.stride(0), x.stride(0), x.stride(1), y.stride(0), y.stride(1), m, k, _BLOCK_SIZE_1, _RDIM_SIZE_0, _BLOCK_SIZE_2, num_warps=4, num_stages=3)""",
         )
 
     @unittest.skipIf(

--- a/test/test_examples.py
+++ b/test/test_examples.py
@@ -170,7 +170,6 @@ def _matmul_make_precompiler(x: torch.Tensor, y: torch.Tensor):
                     bias=args[3],
                 ),
                 block_sizes=[16, 16],
-                l2_grouping=4,
                 static_shapes=True,
             ),
             """\
@@ -265,7 +264,6 @@ def _matmul_layernorm_make_precompiler(x: torch.Tensor, y: torch.Tensor, weight:
                     bias=args[3],
                 ),
                 block_sizes=[16, 16],
-                l2_grouping=4,
                 static_shapes=False,
             ),
             """\


### PR DESCRIPTION
As titled. Things that are worthy to note:
1. Add `hl.register_reduction_dim()` API.
2. Adding handling `var_mean` (a reduction) returning a tuple of two nodes (or for ops to return multiple nodes in general).
3. Since Welford reduction is currently not supported in Helion yet, I changed the variance calculation to always use the "two-step variance" algorithm by patching the Inductor lowering of `var_mean` op. Once Welford reduction is supported, we can remove that patch and switch back to use Inductor `var_mean_helper_()`. At the same time I think the patching mechanism is useful in the development phase where Helion doesn't support specific Inductor lowerings yet.