### PR TITLE
Add filecheck dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ requires-python = ">=3.10"
 dependencies = [
     "torch>=2.7.0",
     "typing_extensions>=4.0.0",
+    "filecheck",
 ]
 
 [project.optional-dependencies]

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ expecttest
 pytest
 typing_extensions
 pre-commit
+filecheck


### PR DESCRIPTION
Stacked PRs:
 * #94
 * #93
 * __->__#95


--- --- ---

### Add filecheck dependency


CI is failing with:
```
File ".../triton/_filecheck.py", line 6, in <module>
    from filecheck.options import Options
ModuleNotFoundError: No module named 'filecheck'
```