### PR TITLE
Re-enable unit test for moe_matmul_ogs example; skip in fbcode

### DIFF
--- a/examples/moe_matmul_ogs.py
+++ b/examples/moe_matmul_ogs.py
@@ -39,49 +39,51 @@ def moe_matmul_ogs(
         start = expert_token_offsets[e_idx]  # Starting index in sorted token array
         num_tokens = expert_token_counts[e_idx]  # Number of tokens for this expert
 
-        # Tile over tokens and output features for this expert
-        for tile_t, tile_n in hl.tile([max_T_per_expert, N]):
-            # Get local token offsets for this tile
-            # (i.e. the tile's corresponding chunk in [0 .. max_T_per_expert-1] token range)
-            local_token_offsets = tile_t.index  # [BLOCK_T]
+        # Skip experts with no assigned tokens
+        if num_tokens != 0:
+            # Tile over tokens and output features for this expert
+            for tile_t, tile_n in hl.tile([max_T_per_expert, N]):
+                # Get local token offsets for this tile
+                # (i.e. the tile's corresponding chunk in [0 .. max_T_per_expert-1] token range)
+                local_token_offsets = tile_t.index  # [BLOCK_T]
 
-            # Create mask for valid tokens (some tiles may be partially filled)
-            token_valid = local_token_offsets < num_tokens  # bool[BLOCK_T]
+                # Create mask for valid tokens (some tiles may be partially filled)
+                token_valid = local_token_offsets < num_tokens  # bool[BLOCK_T]
 
-            # For invalid tokens, use 0 as a dummy index (will be masked out later)
-            local_token_offsets_valid = torch.where(
-                token_valid,
-                local_token_offsets,
-                0,
-            )  # [BLOCK_T]
+                # For invalid tokens, use 0 as a dummy index (will be masked out later)
+                local_token_offsets_valid = torch.where(
+                    token_valid,
+                    local_token_offsets,
+                    0,
+                )  # [BLOCK_T]
 
-            # Convert local offsets to global sorted indices
-            expert_sorted_token_indices = (
-                start + local_token_offsets_valid
-            )  # [1, BLOCK_T]
+                # Convert local offsets to global sorted indices
+                expert_sorted_token_indices = (
+                    start + local_token_offsets_valid
+                )  # [1, BLOCK_T]
 
-            # Map sorted indices back to global original token positions
-            expert_orig_token_indices = sorted_to_orig_token_idx[
-                expert_sorted_token_indices.squeeze(0)
-            ]  # [BLOCK_T]
+                # Map sorted indices back to global original token positions
+                expert_orig_token_indices = sorted_to_orig_token_idx[
+                    expert_sorted_token_indices.squeeze(0)
+                ]  # [BLOCK_T]
 
-            acc = hl.zeros([tile_t, tile_n], dtype=torch.float32)
+                acc = hl.zeros([tile_t, tile_n], dtype=torch.float32)
 
-            # Perform tiled matrix multiplication: A[tokens, :] @ W[expert, :, :]
-            for tile_k in hl.tile(K):
-                A_frag = A[expert_orig_token_indices, tile_k]  # [BLOCK_T, BLOCK_K]
-                W_frag = W[e_idx, tile_k, tile_n]  # [BLOCK_K, BLOCK_N]
-                acc = torch.addmm(acc, A_frag, W_frag)
+                # Perform tiled matrix multiplication: A[tokens, :] @ W[expert, :, :]
+                for tile_k in hl.tile(K):
+                    A_frag = A[expert_orig_token_indices, tile_k]  # [BLOCK_T, BLOCK_K]
+                    W_frag = W[e_idx, tile_k, tile_n]  # [BLOCK_K, BLOCK_N]
+                    acc = torch.addmm(acc, A_frag, W_frag)
 
-            # Write results back to output tensor, masking out invalid tokens
-            block_T = acc.size(0)
-            block_N = acc.size(1)
-            existing_values = C[expert_orig_token_indices, tile_n]
-            mask_2d = token_valid.view(block_T, 1).expand(block_T, block_N)
-            # Write results only for valid tokens, preserve existing values for invalid ones
-            C[expert_orig_token_indices, tile_n] = torch.where(
-                mask_2d, acc.to(C.dtype), existing_values
-            )
+                # Write results back to output tensor, masking out invalid tokens
+                block_T = acc.size(0)
+                block_N = acc.size(1)
+                existing_values = C[expert_orig_token_indices, tile_n]
+                mask_2d = token_valid.view(block_T, 1).expand(block_T, block_N)
+                # Write results only for valid tokens, preserve existing values for invalid ones
+                C[expert_orig_token_indices, tile_n] = torch.where(
+                    mask_2d, acc.to(C.dtype), existing_values
+                )
 
     return C
 


### PR DESCRIPTION
The `if num_tokens != 0:` check is essential for the correctness of the kernel, but the check triggers Triton internal error on fbcode. So skipping the MoE unit test on fbcode only for now.