### PR TITLE
[BC breaking] Simplify block size configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,15 +179,17 @@ and configurations directly from your code.
 
 Helion configurations include the following options:
 
-* **block\_sizes** (`list[int | list[int]]`):
-Controls tile sizes corresponding to each `hl.tile` invocation in the
-kernel. For tiles with two or more dimensions, you can use either an
-integer to flatten the iteration space into a single dimension or a list
-of integers for multi-dimensional tiling.
+* **block\_sizes** (`list[int]`):
+Controls tile sizes corresponding to each dimension passed `hl.tile` or call
+to `hl.register_block_size` in the kernel.
 
 * **loop\_orders** (`list[list[int]]`):
 Contains one entry per `hl.tile` call with two or more dimensions,
 allowing you to permute the iteration order of the tiles.
+
+* **flatten_loops** (`list[bool]`):
+Contains one entry per `hl.tile` call with two or more dimensions,
+allowing you to flatten the iteration space into a single dimension.
 
 * **reduction\_loops** (`list[int | None]`):
 Contains one entry per reduction dimension (see

--- a/examples/attention.py
+++ b/examples/attention.py
@@ -12,7 +12,7 @@ import helion.language as hl
 @helion.kernel(
     config=helion.Config(
         # This config was autotuned on a 3090, it won't be fast for other architectures
-        block_sizes=[[32], [16]],
+        block_sizes=[32, 16],
         num_warps=1,
         num_stages=2,
         indexing="block_ptr",

--- a/examples/embedding.py
+++ b/examples/embedding.py
@@ -8,7 +8,7 @@ import helion.language as hl
 
 @helion.kernel(
     config=helion.Config(
-        block_size=[512, 32], loop_order=[0, 1], num_warps=8, indexing="block_ptr"
+        block_sizes=[512, 32], loop_order=[0, 1], num_warps=8, indexing="block_ptr"
     )
 )
 def embedding(x: torch.Tensor, weight: torch.Tensor) -> torch.Tensor:

--- a/examples/jagged_dense_add.py
+++ b/examples/jagged_dense_add.py
@@ -21,7 +21,7 @@ jagged matrix x.  It is intended to illustrate how to work with jagged tensors.
 
 @helion.kernel(
     config=helion.Config(
-        block_sizes=[[1], [512], [512]], num_warps=8, num_stages=4, indexing="block_ptr"
+        block_sizes=[1, 512, 512], num_warps=8, num_stages=4, indexing="block_ptr"
     )
 )
 def jagged_dense_add_2d(

--- a/examples/long_sum.py
+++ b/examples/long_sum.py
@@ -13,7 +13,7 @@ def baseline_sum(x: torch.Tensor) -> torch.Tensor:
 # Naive Reduction: Load the entire reduction dim at once, and reduce in reg.
 @helion.kernel(
     config=helion.Config(
-        block_sizes=[[1]],
+        block_sizes=[1],
         reduction_loops=[None],
         num_warps=32,
         num_stages=4,
@@ -32,7 +32,7 @@ def longsum(x: torch.Tensor) -> torch.Tensor:
 # Looped reduction
 @helion.kernel(
     config=helion.Config(
-        block_sizes=[[1]],
+        block_sizes=[1],
         reduction_loops=[
             32768
         ],  # [None] for naive reduction, [tile_size] for looped reduction
@@ -53,7 +53,7 @@ def longsum_w_red_loop(x: torch.Tensor) -> torch.Tensor:
 # This generates the same code as above, but manually implements looped reduction.
 @helion.kernel(
     config=helion.Config(
-        block_sizes=[[32768], [1]], num_warps=16, num_stages=5, indexing="pointer"
+        block_sizes=[32768, 1], num_warps=16, num_stages=5, indexing="pointer"
     )
 )
 def longsum_manual(x: torch.Tensor) -> torch.Tensor:

--- a/examples/template_via_closure.py
+++ b/examples/template_via_closure.py
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
 @helion.kernel(
     # This was tuned on a 3090 and likely isn't optimal for other GPUs
     config=helion.Config(
-        block_sizes=[[64, 64], [16]],
+        block_sizes=[64, 64, 16],
         loop_orders=[[0, 1]],
         num_warps=2,
         num_stages=3,

--- a/helion/_compiler/tile_dispatch.py
+++ b/helion/_compiler/tile_dispatch.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import collections
+import functools
+import operator
 from typing import TYPE_CHECKING
 
 from helion._compiler.compile_environment import CompileEnvironment
@@ -74,10 +76,13 @@ class TileStrategyDispatch:
                 loop_order=loop_order,
             )
         elif block_size_infos[0].is_flattened(config):
+            block_size = functools.reduce(
+                operator.mul, [bs.from_config_assert(config) for bs in block_size_infos]
+            )
             strategy: TileStrategy = FlattenedTileStrategy(
                 fn,
                 block_indices,
-                block_size=block_size_infos[0].from_config_assert(config),
+                block_size=block_size,
                 loop_order=loop_order,
             )
         else:

--- a/helion/autotuner/config_generation.py
+++ b/helion/autotuner/config_generation.py
@@ -52,7 +52,7 @@ class ConfigGeneration:
             if spec.category() == Category.NUM_WARPS
         )
         self.min_block_size: int = max(
-            [max(spec.min_sizes) for spec in config_spec.block_size_specs]
+            [spec.min_size for spec in config_spec.block_sizes]
         )
 
     def unflatten(self, flat_values: FlatConfig) -> Config:

--- a/helion/runtime/config.py
+++ b/helion/runtime/config.py
@@ -20,8 +20,9 @@ class Config(Mapping[str, object]):
         self,
         *,
         # Core properties
-        block_sizes: list[int | list[int]] | None = None,
+        block_sizes: list[int] | None = None,
         loop_orders: list[list[int]] | None = None,
+        flatten_loops: list[bool] | None = None,
         l2_groupings: list[int] | None = None,
         reduction_loops: list[int | None] | None = None,
         num_warps: int | None = None,
@@ -49,6 +50,7 @@ class Config(Mapping[str, object]):
         core_props = {
             "block_sizes": block_sizes,
             "loop_orders": loop_orders,
+            "flatten_loops": flatten_loops,
             "l2_groupings": l2_groupings,
             "reduction_loops": reduction_loops,
             "num_warps": num_warps,
@@ -105,12 +107,16 @@ class Config(Mapping[str, object]):
         return cls.from_json(Path(path).read_text())
 
     @property
-    def block_sizes(self) -> list[int | list[int]]:
-        return cast("list[int | list[int]]", self.config["block_sizes"])
+    def block_sizes(self) -> list[int]:
+        return cast("list[int]", self.config["block_sizes"])
 
     @property
     def loop_orders(self) -> list[list[int]]:
         return cast("list[list[int]]", self.config.get("loop_orders", []))
+
+    @property
+    def flatten_loops(self) -> list[bool]:
+        return cast("list[bool]", self.config.get("flatten_loops", []))
 
     @property
     def reduction_loops(self) -> list[int | None]:

--- a/test/test_autotuner.py
+++ b/test/test_autotuner.py
@@ -42,16 +42,16 @@ class TestAutotuner(TestCase):
         self.assertExpectedInline(
             "\n".join(map(repr, configs)),
             """\
-helion.Config(block_sizes=[[16, 16], [16]], loop_orders=[[0, 1]], l2_groupings=[1], num_warps=4, num_stages=3, indexing='pointer', use_yz_grid=False)
-helion.Config(block_sizes=[[32, 128], [64]], loop_orders=[[1, 0]], l2_groupings=[8], num_warps=32, num_stages=3, indexing='block_ptr')
-helion.Config(block_sizes=[[128, 16], [128]], loop_orders=[[0, 1]], l2_groupings=[8], num_warps=4, num_stages=6, indexing='pointer')
-helion.Config(block_sizes=[[16, 16], [16]], loop_orders=[[0, 1]], l2_groupings=[16], num_warps=4, num_stages=7, indexing='tensor_descriptor')
-helion.Config(block_sizes=[[16, 16], [16]], loop_orders=[[0, 1]], l2_groupings=[8], num_warps=32, num_stages=2, indexing='tensor_descriptor')
-helion.Config(block_sizes=[[16, 16], [16]], loop_orders=[[1, 0]], l2_groupings=[64], num_warps=4, num_stages=7, indexing='tensor_descriptor')
-helion.Config(block_sizes=[[32, 16], [16]], loop_orders=[[0, 1]], l2_groupings=[16], num_warps=4, num_stages=4, indexing='tensor_descriptor')
-helion.Config(block_sizes=[[64, 16], [128]], loop_orders=[[0, 1]], l2_groupings=[4], num_warps=32, num_stages=2, indexing='tensor_descriptor')
-helion.Config(block_sizes=[[16, 16], [16]], loop_orders=[[0, 1]], l2_groupings=[16], num_warps=16, num_stages=3, indexing='block_ptr')
-helion.Config(block_sizes=[[16, 32], [32]], loop_orders=[[0, 1]], l2_groupings=[4], num_warps=4, num_stages=7, indexing='block_ptr')""",
+helion.Config(block_sizes=[16, 16, 16], loop_orders=[[0, 1]], l2_groupings=[1], num_warps=4, num_stages=3, indexing='pointer')
+helion.Config(block_sizes=[16, 32, 16], loop_orders=[[1, 0]], l2_groupings=[8], num_warps=32, num_stages=3, indexing='block_ptr')
+helion.Config(block_sizes=[32, 16, 16], loop_orders=[[1, 0]], l2_groupings=[32], num_warps=8, num_stages=8, indexing='block_ptr')
+helion.Config(block_sizes=[16, 16, 32], loop_orders=[[0, 1]], l2_groupings=[16], num_warps=4, num_stages=7, indexing='tensor_descriptor')
+helion.Config(block_sizes=[16, 16, 16], loop_orders=[[0, 1]], l2_groupings=[4], num_warps=8, num_stages=2, indexing='tensor_descriptor')
+helion.Config(block_sizes=[16, 16, 16], loop_orders=[[1, 0]], l2_groupings=[64], num_warps=4, num_stages=7, indexing='tensor_descriptor')
+helion.Config(block_sizes=[32, 128, 64], loop_orders=[[0, 1]], l2_groupings=[2], num_warps=16, num_stages=5, indexing='pointer')
+helion.Config(block_sizes=[16, 16, 16], loop_orders=[[1, 0]], l2_groupings=[2], num_warps=16, num_stages=3, indexing='tensor_descriptor')
+helion.Config(block_sizes=[16, 16, 16], loop_orders=[[0, 1]], l2_groupings=[16], num_warps=4, num_stages=2, indexing='block_ptr')
+helion.Config(block_sizes=[16, 16, 16], loop_orders=[[0, 1]], l2_groupings=[1], num_warps=1, num_stages=1, indexing='tensor_descriptor')""",
         )
 
     @patch.object(_compat, "_supports_tensor_descriptor", lambda: True)
@@ -65,21 +65,21 @@ helion.Config(block_sizes=[[16, 32], [32]], loop_orders=[[0, 1]], l2_groupings=[
         self.assertExpectedInline(
             "\n".join(map(repr, configs)),
             """\
-helion.Config(block_sizes=[[8, 16, 16]], loop_orders=[[0, 1, 2]], num_warps=4, num_stages=3, indexing='pointer', use_yz_grid=False)
-helion.Config(block_sizes=[256], loop_orders=[[1, 0, 2]], num_warps=2, num_stages=8, indexing='pointer')
-helion.Config(block_sizes=[256], loop_orders=[[0, 2, 1]], num_warps=32, num_stages=8, indexing='tensor_descriptor')
-helion.Config(block_sizes=[[8, 16, 1]], loop_orders=[[2, 0, 1]], num_warps=8, num_stages=2, indexing='tensor_descriptor', use_yz_grid=False)
-helion.Config(block_sizes=[1], loop_orders=[[1, 2, 0]], num_warps=4, num_stages=7, indexing='pointer')
-helion.Config(block_sizes=[[1, 2, 128]], loop_orders=[[1, 0, 2]], num_warps=32, num_stages=2, indexing='block_ptr', use_yz_grid=False)
-helion.Config(block_sizes=[[1, 16, 2]], loop_orders=[[0, 1, 2]], num_warps=4, num_stages=2, indexing='pointer', use_yz_grid=False)
-helion.Config(block_sizes=[4096], loop_orders=[[1, 0, 2]], num_warps=1, num_stages=2, indexing='tensor_descriptor')
-helion.Config(block_sizes=[[1, 2, 1]], loop_orders=[[1, 0, 2]], num_warps=4, num_stages=7, indexing='block_ptr', use_yz_grid=False)
-helion.Config(block_sizes=[1], loop_orders=[[2, 1, 0]], num_warps=1, num_stages=8, indexing='block_ptr')""",
+helion.Config(block_sizes=[8, 16, 16], loop_orders=[[0, 1, 2]], flatten_loops=[False], num_warps=4, num_stages=3, indexing='pointer')
+helion.Config(block_sizes=[1, 64, 64], loop_orders=[[1, 2, 0]], flatten_loops=[False], num_warps=4, num_stages=4, indexing='tensor_descriptor')
+helion.Config(block_sizes=[1, 64, 512], loop_orders=[[0, 1, 2]], flatten_loops=[True], num_warps=4, num_stages=4, indexing='pointer')
+helion.Config(block_sizes=[1, 64, 128], loop_orders=[[1, 2, 0]], flatten_loops=[True], num_warps=1, num_stages=2, indexing='pointer')
+helion.Config(block_sizes=[2, 16, 64], loop_orders=[[2, 0, 1]], flatten_loops=[False], num_warps=2, num_stages=5, indexing='tensor_descriptor')
+helion.Config(block_sizes=[8, 1, 16], loop_orders=[[2, 1, 0]], flatten_loops=[True], num_warps=16, num_stages=7, indexing='pointer')
+helion.Config(block_sizes=[1, 8, 512], loop_orders=[[1, 0, 2]], flatten_loops=[True], num_warps=8, num_stages=4, indexing='tensor_descriptor')
+helion.Config(block_sizes=[2, 2, 32], loop_orders=[[2, 0, 1]], flatten_loops=[True], num_warps=1, num_stages=8, indexing='pointer')
+helion.Config(block_sizes=[2, 16, 2], loop_orders=[[0, 2, 1]], flatten_loops=[True], num_warps=4, num_stages=7, indexing='block_ptr')
+helion.Config(block_sizes=[2, 16, 2], loop_orders=[[0, 2, 1]], flatten_loops=[True], num_warps=1, num_stages=3, indexing='block_ptr')""",
         )
 
     def test_save_load_config(self):
         config = helion.Config(
-            block_sizes=[[64, 64], [32]],
+            block_sizes=[64, 64, 32],
             loop_orders=[[1, 0]],
             num_warps=2,
             num_stages=1,
@@ -95,13 +95,9 @@ helion.Config(block_sizes=[1], loop_orders=[[2, 1, 0]], num_warps=1, num_stages=
             """\
 {
   "block_sizes": [
-    [
-      64,
-      64
-    ],
-    [
-      32
-    ]
+    64,
+    64,
+    32
   ],
   "loop_orders": [
     [
@@ -119,7 +115,10 @@ helion.Config(block_sizes=[1], loop_orders=[[2, 1, 0]], num_warps=1, num_stages=
     def test_run_fixed_config(self):
         @helion.kernel(
             config=helion.Config(
-                block_sizes=[1024], loop_orders=[[0, 2, 1]], num_warps=8
+                block_sizes=[1024, 1, 1],
+                flatten_loops=[True],
+                loop_orders=[[0, 2, 1]],
+                num_warps=8,
             )
         )
         def add(a, b):
@@ -137,8 +136,15 @@ helion.Config(block_sizes=[1], loop_orders=[[2, 1, 0]], num_warps=1, num_stages=
     def test_run_finite_search(self):
         @helion.kernel(
             configs=[
-                helion.Config(block_sizes=[1024], loop_orders=[[0, 2, 1]], num_warps=8),
-                helion.Config(block_sizes=[1024], num_warps=8),
+                helion.Config(
+                    block_sizes=[1024, 1, 1],
+                    flatten_loops=[True],
+                    loop_orders=[[0, 2, 1]],
+                    num_warps=8,
+                ),
+                helion.Config(
+                    block_sizes=[1024, 1, 1], flatten_loops=[True], num_warps=8
+                ),
                 helion.Config(block_sizes=[1, 64, 64], num_warps=8),
                 helion.Config(block_sizes=[1, 1, 512], num_warps=8),
             ],

--- a/test/test_control_flow.py
+++ b/test/test_control_flow.py
@@ -87,7 +87,13 @@ def _fn_make_precompiler(x, v):
         )
 
     def test_constant_true(self):
-        @helion.kernel(config={"block_size": 128, "indexing": "block_ptr"})
+        @helion.kernel(
+            config={
+                "block_sizes": [128, 1],
+                "flatten_loop": True,
+                "indexing": "block_ptr",
+            }
+        )
         def fn(x):
             out = torch.empty_like(x)
             v = 4

--- a/test/test_generate_ast.py
+++ b/test/test_generate_ast.py
@@ -61,7 +61,9 @@ def _add_make_precompiler(x, y):
             torch.randn([100, 500], device=DEVICE),
             torch.randn([100, 500], device=DEVICE),
         )
-        code, result = code_and_output(basic_kernels.add, args, block_size=1024)
+        code, result = code_and_output(
+            basic_kernels.add, args, block_sizes=[1024, 1], flatten_loop=True
+        )
         torch.testing.assert_close(result, args[0] + args[1])
         self.assertExpectedInline(
             code,
@@ -104,7 +106,11 @@ def _add_make_precompiler(x, y):
             torch.randn([100, 500], device=DEVICE),
         )
         code, result = code_and_output(
-            basic_kernels.add, args, block_size=1024, loop_order=(1, 0)
+            basic_kernels.add,
+            args,
+            block_sizes=[1024, 1],
+            flatten_loops=[True],
+            loop_order=(1, 0),
         )
         torch.testing.assert_close(result, args[0] + args[1])
         self.assertExpectedInline(
@@ -147,7 +153,9 @@ def _add_make_precompiler(x, y):
             torch.randn([100, 500, 10], device=DEVICE),
             torch.randn([100, 500, 10], device=DEVICE),
         )
-        code, result = code_and_output(basic_kernels.add, args, block_size=1024)
+        code, result = code_and_output(
+            basic_kernels.add, args, block_sizes=[1024, 1, 1], flatten_loop=True
+        )
         torch.testing.assert_close(result, args[0] + args[1])
         self.assertExpectedInline(
             code,
@@ -191,7 +199,7 @@ def _add_make_precompiler(x, y):
             torch.randn([100, 500, 10], device=DEVICE),
         )
         code, result = code_and_output(
-            basic_kernels.add, args, block_size=[16, 16, 16], use_yz_grid=True
+            basic_kernels.add, args, block_sizes=[16, 16, 16], use_yz_grid=True
         )
         torch.testing.assert_close(result, args[0] + args[1])
         self.assertExpectedInline(
@@ -247,7 +255,11 @@ def _add_make_precompiler(x, y):
             torch.randn([100, 500, 10], device=DEVICE),
         )
         code, result = code_and_output(
-            basic_kernels.add, args, block_size=1024, loop_order=(2, 0, 1)
+            basic_kernels.add,
+            args,
+            block_sizes=[1024, 1, 1],
+            flatten_loop=True,
+            loop_order=(2, 0, 1),
         )
         torch.testing.assert_close(result, args[0] + args[1])
         self.assertExpectedInline(
@@ -292,7 +304,7 @@ def _add_make_precompiler(x, y):
             torch.randn([512, 512, 512], device=DEVICE),
         )
         code, result = code_and_output(
-            basic_kernels.add, args, block_size=[8, 16, 32], loop_order=(0, 1, 2)
+            basic_kernels.add, args, block_sizes=[8, 16, 32], loop_order=(0, 1, 2)
         )
         torch.testing.assert_close(result, args[0] + args[1])
         self.assertExpectedInline(
@@ -350,7 +362,7 @@ def _add_make_precompiler(x, y):
             torch.randn([512, 512, 512], device=DEVICE),
         )
         code, result = code_and_output(
-            basic_kernels.add, args, block_size=[8, 16, 32], loop_order=(2, 1, 0)
+            basic_kernels.add, args, block_sizes=[8, 16, 32], loop_order=(2, 1, 0)
         )
         torch.testing.assert_close(result, args[0] + args[1])
         self.assertExpectedInline(
@@ -408,7 +420,7 @@ def _add_make_precompiler(x, y):
             torch.randn([512, 512, 512], device=DEVICE),
         )
         code, result = code_and_output(
-            basic_kernels.add, args, block_size=[1, 32, 32], loop_order=(0, 1, 2)
+            basic_kernels.add, args, block_sizes=[1, 32, 32], loop_order=(0, 1, 2)
         )
         torch.testing.assert_close(result, args[0] + args[1])
         self.assertExpectedInline(
@@ -465,7 +477,7 @@ def _add_make_precompiler(x, y):
         code, result = code_and_output(
             basic_kernels.add,
             args,
-            block_size=[1, 32, 1],
+            block_sizes=[1, 32, 1],
             loop_order=(0, 2, 1),
             num_warps=8,
             num_stages=1,
@@ -569,7 +581,7 @@ def _torch_ops_pointwise_make_precompiler(x, y):
         code, result = code_and_output(
             basic_kernels.hl_zeros_usage,
             args,
-            block_size=[32, 32],
+            block_sizes=[32, 32],
         )
         torch.testing.assert_close(result, args[0] * 2)
         self.assertExpectedInline(
@@ -662,7 +674,8 @@ def _hl_full_usage_make_precompiler(x: torch.Tensor):
         code, result = code_and_output(
             basic_kernels.hl_zeros_usage,
             args,
-            block_size=128,
+            block_sizes=[128, 1],
+            flatten_loops=[True],
         )
         torch.testing.assert_close(result, args[0] * 2)
         self.assertExpectedInline(
@@ -706,7 +719,8 @@ def _hl_zeros_usage_make_precompiler(x: torch.Tensor):
         code, result = code_and_output(
             basic_kernels.inplace_mul,
             args,
-            block_size=128,
+            block_size=[128, 1],
+            flatten_loop=True,
         )
         torch.testing.assert_close(result, eager_result)
         self.assertExpectedInline(

--- a/test/test_logging.py
+++ b/test/test_logging.py
@@ -28,7 +28,7 @@ class TestLogging(TestCase):
     def test_kernel_log(self):
         @helion.kernel(
             config=helion.Config(
-                block_sizes=[[1]], num_warps=16, num_stages=8, indexing="pointer"
+                block_sizes=[1], num_warps=16, num_stages=8, indexing="pointer"
             )
         )
         def add(x, y):

--- a/test/test_matmul.py
+++ b/test/test_matmul.py
@@ -78,7 +78,7 @@ class TestMatmul(TestCase):
         code, output = code_and_output(
             matmul_without_addmm,
             args,
-            block_sizes=[[16, 16], 16],
+            block_sizes=[16, 16, 16],
             l2_grouping=4,
         )
         torch.testing.assert_close(output, args[0] @ args[1], atol=1e-1, rtol=1e-2)
@@ -147,7 +147,7 @@ def _matmul_without_addmm_make_precompiler(x: torch.Tensor, y: torch.Tensor):
         code, output = code_and_output(
             examples_matmul,
             args,
-            block_sizes=[[16, 16], 16],
+            block_sizes=[16, 16, 16],
             loop_order=[1, 0],
         )
         torch.testing.assert_close(output, args[0] @ args[1], atol=1e-1, rtol=1e-2)
@@ -209,7 +209,7 @@ def _matmul_make_precompiler(x: torch.Tensor, y: torch.Tensor):
         code, output = code_and_output(
             matmul_with_addmm,
             args,
-            block_sizes=[[16, 16], 16],
+            block_sizes=[16, 16, 16],
             l2_grouping=4,
         )
         torch.testing.assert_close(output, args[0] @ args[1], atol=1e-1, rtol=1e-2)
@@ -277,7 +277,7 @@ def _matmul_with_addmm_make_precompiler(x: torch.Tensor, y: torch.Tensor):
         code, output = code_and_output(
             examples_matmul,
             args,
-            block_sizes=[[16, 16], 16],
+            block_sizes=[16, 16, 16],
             l2_grouping=4,
             indexing="block_ptr",
         )
@@ -341,7 +341,7 @@ def _matmul_make_precompiler(x: torch.Tensor, y: torch.Tensor):
             torch.randn([128, 128], device=DEVICE, dtype=torch.float32),
         )
         config = Config(
-            block_sizes=[[16, 16], 16],
+            block_sizes=[16, 16, 16],
             l2_grouping=4,
             indexing="tensor_descriptor",
         )
@@ -408,7 +408,7 @@ def _matmul_make_precompiler(x: torch.Tensor, y: torch.Tensor):
         code, output = code_and_output(
             matmul_static_shapes,
             args,
-            block_sizes=[[16, 16], 16],
+            block_sizes=[16, 16, 16],
             l2_grouping=4,
             indexing="pointer",
         )
@@ -477,7 +477,7 @@ def _matmul_static_shapes_make_precompiler(x: torch.Tensor, y: torch.Tensor):
         code, output = code_and_output(
             matmul_static_shapes,
             args,
-            block_sizes=[[16, 16], 16],
+            block_sizes=[16, 16, 16],
             l2_grouping=4,
         )
         torch.testing.assert_close(output, args[0] @ args[1], atol=1e-1, rtol=1e-2)
@@ -546,7 +546,7 @@ def _matmul_static_shapes_make_precompiler(x: torch.Tensor, y: torch.Tensor):
         code, output = code_and_output(
             matmul_static_shapes,
             args,
-            block_sizes=[[16, 16], 16],
+            block_sizes=[16, 16, 16],
             l2_grouping=4,
         )
         torch.testing.assert_close(output, args[0] @ args[1], atol=1e-1, rtol=1e-2)
@@ -602,7 +602,7 @@ def matmul_static_shapes(x: torch.Tensor, y: torch.Tensor):
         code, output = code_and_output(
             matmul_static_shapes,
             args,
-            block_sizes=[[16, 16], 16],
+            block_sizes=[16, 16, 16],
             l2_grouping=4,
         )
         torch.testing.assert_close(output, args[0] @ args[1], atol=1e-1, rtol=1e-2)

--- a/test/test_specialize.py
+++ b/test/test_specialize.py
@@ -28,7 +28,7 @@ class TestSpecialize(TestCase):
             return out
 
         x = torch.randn([512, 512], device=DEVICE)
-        code, result = code_and_output(fn, (x,), block_size=32)
+        code, result = code_and_output(fn, (x,), block_sizes=[32, 1], flatten_loop=True)
         torch.testing.assert_close(result, x / math.sqrt(x.size(-1)))
         self.assertExpectedInline(
             code,
@@ -78,7 +78,7 @@ def _fn_make_precompiler(x: torch.Tensor):
             return out
 
         x = torch.randn([500, 500], device=DEVICE)
-        code, result = code_and_output(fn, (x,), block_size=[32, 32])
+        code, result = code_and_output(fn, (x,), block_sizes=[32, 32])
         torch.testing.assert_close(result, x / math.sqrt(x.size(-1)))
         self.assertExpectedInline(
             code,


### PR DESCRIPTION
Stacked PRs:
 * #132
 * #131
 * #130
 * #129
 * #128
 * __->__#127
 * #126


--- --- ---

### [BC breaking] Simplify block size configs


This removes the prior nested config structure where you would have:
block_sizes=[[8, 8], 8] for nested loops, and
block_sizes=[64, 8] for a flattened loop.

Instead, you would now have:
block_sizes=[8, 8, 8], flatten_loops=[False] for nested loops, and
block_sizes=[8, 8, 8] flatten_loops=[True] for a flattened loop

This makes config structures more predictable and easier to work with.
