### PR TITLE
Increase atol/rtol for test_error_in_non_taken_branch

### DIFF
--- a/test/test_control_flow.py
+++ b/test/test_control_flow.py
@@ -255,6 +255,8 @@ def _fn_make_precompiler(x):
         torch.testing.assert_close(
             mul_relu_block_backward_kernel(x, y, dz, False),
             expected,
+            atol=1e-4,
+            rtol=1e-4,
         )
         code, output = code_and_output(
             mul_relu_block_backward_kernel,
@@ -333,6 +335,8 @@ def _mul_relu_block_backward_kernel_make_precompiler(x: torch.Tensor, y: torch.T
         torch.testing.assert_close(
             output,
             expected,
+            atol=1e-4,
+            rtol=1e-4,
         )
 
 


### PR DESCRIPTION
Stacked PRs:
 * #141
 * __->__#142


--- --- ---

This test was failing:
https://github.com/pytorch-labs/helion/actions/runs/15520524821/job/43693128974?pr=141

It looks like noise:
```
Mismatched elements: 1 / 512 (0.2%)
Greatest absolute difference: 1.0371208190917969e-05 at index (65,) (up to 1e-05 allowed)
Greatest relative difference: 4.182314296485856e-05 at index (65,) (up to 1.3e-06 allowed)
```