### PR TITLE
Fix visitCall in deviceIR. Always visit argument nodes

### DIFF
--- a/helion/_compiler/device_ir.py
+++ b/helion/_compiler/device_ir.py
@@ -422,9 +422,6 @@ class WalkDeviceAST(NodeVisitor):
 
     def _to_proxy(self, node: ast.AST) -> object:
         assert isinstance(node, ExtendedAST)
-        type_info = node._type_info
-        if not type_info.contains_tensor():
-            return type_info.proxy()
         return self.visit(node)
 
     def visit_BinOp(self, node: ast.BinOp) -> object:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #178

