### PR TITLE
Fix deviceIR.visitCall: Always visit arg nodes

### DIFF
--- a/helion/_compiler/device_ir.py
+++ b/helion/_compiler/device_ir.py
@@ -422,9 +422,6 @@ class WalkDeviceAST(NodeVisitor):
 
     def _to_proxy(self, node: ast.AST) -> object:
         assert isinstance(node, ExtendedAST)
-        type_info = node._type_info
-        if not type_info.contains_tensor():
-            return type_info.proxy()
         return self.visit(node)
 
     def visit_BinOp(self, node: ast.BinOp) -> object:


### PR DESCRIPTION
ghstack-source-id: fefa4f8e9d0a1ff27cdd1abdffba9e3d4e2319a4
Pull Request resolved: https://github.com/pytorch-labs/helion/pull/178