### PR TITLE
[benchmarks] Change tritonbench api

### DIFF
--- a/benchmarks/run.py
+++ b/benchmarks/run.py
@@ -224,7 +224,7 @@ def main() -> None:
 
     # Register the Helion kernel with tritonbench BEFORE importing the operator
     from tritonbench.utils.triton_op import (  # pyre-ignore[21]
-        register_benchmark_mannually,
+        register_benchmark,
     )
 
     # Create the benchmark method
@@ -255,7 +255,7 @@ def main() -> None:
 
     # Register it as a benchmark first
     helion_method_name = f"helion_{kernel_name}"
-    register_benchmark_mannually(
+    register_benchmark(
         operator_name=operator_name,
         func_name=helion_method_name,
         baseline=False,


### PR DESCRIPTION
Tritonbench is removing `register_benchmark_manually` API and merging it with `register_benchmark`: https://github.com/pytorch-labs/tritonbench/blob/main/tritonbench/utils/triton_op.py#L582, https://github.com/pytorch-labs/tritonbench/blob/main/tritonbench/utils/triton_op.py#L618

