### PR TITLE
Enforce ANN/PGH lints

### DIFF
--- a/benchmarks/run.py
+++ b/benchmarks/run.py
@@ -263,9 +263,9 @@ def run_kernel(kernel_name: str, tritonbench_args: list[str]) -> None:
 
     # Create the benchmark method
     def helion_method(
-        self: Any,
-        *args: Any,
-    ) -> Callable[..., Any]:
+        self: object,
+        *args: object,
+    ) -> Callable[..., object]:
         """Helion implementation."""
 
         # Reset all Helion kernels before creating the benchmark function

--- a/examples/all_gather_matmul.py
+++ b/examples/all_gather_matmul.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import os
-from typing import Any
 
 import torch
 import torch.distributed as dist
@@ -118,7 +117,7 @@ def helion_all_gather_matmul(
     b: torch.Tensor,
     a_out: torch.Tensor | None = None,
     progress: torch.Tensor | None = None,
-    **kwargs: Any,
+    **kwargs: int,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     configs = {
         "SPLITS_PER_RANK": kwargs.get("splits_per_rank", 1),

--- a/helion/_compiler/ast_extension.py
+++ b/helion/_compiler/ast_extension.py
@@ -234,7 +234,7 @@ _needs_to_remove_tuple_parens: bool = (
 class _TupleParensRemovedUnparser(
     ast._Unparser  # pyright: ignore[reportAttributeAccessIssue]
 ):
-    def visit_Tuple(self, node) -> None:
+    def visit_Tuple(self, node: ast.Tuple) -> None:
         if _needs_to_remove_tuple_parens and isinstance(
             getattr(node, "ctx", None), ast.Store
         ):

--- a/helion/_compiler/ast_read_writes.py
+++ b/helion/_compiler/ast_read_writes.py
@@ -232,7 +232,7 @@ class _DeletePureExpressions(ast.NodeTransformer):
 def dead_assignment_elimination(
     body: list[ast.AST],
     dce_vars: list[str],
-    num_iterations=8,
+    num_iterations: int = 8,
     input_rw: ReadWrites | None = None,
 ) -> None:
     """

--- a/helion/_compiler/inductor_lowering_extra.py
+++ b/helion/_compiler/inductor_lowering_extra.py
@@ -46,7 +46,7 @@ def _register_inductor_lowering(
     )
 
     @functools.wraps(decomp_fn)  # pyright: ignore[reportArgumentType]
-    def wrapped(*args: Any, **kwargs: Any) -> object:
+    def wrapped(*args: object, **kwargs: object) -> object:
         args = list(args)  # pyright: ignore[reportAssignmentType]
         kwargs = dict(kwargs)
         unpacked = False

--- a/helion/_compiler/traceback_compat.py
+++ b/helion/_compiler/traceback_compat.py
@@ -153,7 +153,7 @@ def _extract_caret_anchors_from_line_segment(segment: str) -> _Anchors | None:
     return None  # fallback - no fancy anchors
 
 
-def format_frame_summary(frame_summary):  # type: ignore[override]
+def format_frame_summary(frame_summary: traceback.FrameSummary) -> str:  # type: ignore[override]
     """Backport of Python 3.11's traceback.StackSummary.format_frame_summary()."""
 
     _ensure_original_line(frame_summary)
@@ -170,18 +170,18 @@ def format_frame_summary(frame_summary):  # type: ignore[override]
         stripped_line = frame_summary.line.strip()
         row.append(f"    {stripped_line}\n")
 
-        line = frame_summary._original_line
+        line = frame_summary._original_line  # type: ignore[attr-defined]
         orig_line_len = len(line)
         frame_line_len = len(frame_summary.line.lstrip())
         stripped_characters = orig_line_len - frame_line_len
 
-        if frame_summary.colno is not None and frame_summary.end_colno is not None:
-            start_offset = _byte_offset_to_character_offset(line, frame_summary.colno)
-            end_offset = _byte_offset_to_character_offset(line, frame_summary.end_colno)
+        if frame_summary.colno is not None and frame_summary.end_colno is not None:  # type: ignore[attr-defined]
+            start_offset = _byte_offset_to_character_offset(line, frame_summary.colno)  # type: ignore[attr-defined]
+            end_offset = _byte_offset_to_character_offset(line, frame_summary.end_colno)  # type: ignore[attr-defined]
             code_segment = line[start_offset:end_offset]
 
             anchors = None
-            if frame_summary.lineno == frame_summary.end_lineno:
+            if frame_summary.lineno == frame_summary.end_lineno:  # type: ignore[attr-defined]
                 with suppress(Exception):
                     anchors = _extract_caret_anchors_from_line_segment(code_segment)
             else:

--- a/helion/_compiler/type_printer.py
+++ b/helion/_compiler/type_printer.py
@@ -51,7 +51,7 @@ class OutputLines:
 class ASTPrinter(_TupleParensRemovedUnparser):
     _indent: int
 
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: object, **kwargs: object) -> None:
         super().__init__(*args, **kwargs)
         assert self._source == []
         self._source = self.output = OutputLines(self)

--- a/helion/autotuner/base_search.py
+++ b/helion/autotuner/base_search.py
@@ -14,6 +14,10 @@ import sys
 import time
 from typing import TYPE_CHECKING
 from typing import NamedTuple
+from typing import NoReturn
+
+if TYPE_CHECKING:
+    from triton.runtime.jit import JITFunction
 
 from torch._inductor.runtime.triton_compat import OutOfResources
 from torch._inductor.runtime.triton_compat import PTXASError
@@ -152,7 +156,7 @@ class BaseSearch:
             grid: tuple[int, ...],
             *args: object,
             **kwargs: object,
-        ):
+        ) -> NoReturn:
             """Custom launcher that extracts arguments instead of executing."""
             raise _ExtractedLaunchArgs(triton_kernel, grid, args, kwargs)
 
@@ -524,7 +528,18 @@ class PrecompileFuture:
 class _ExtractedLaunchArgs(Exception):
     """Exception that carries kernel launch arguments for precompiler extraction."""
 
-    def __init__(self, triton_kernel, grid, args, kwargs):
+    kernel: JITFunction[object]
+    grid: object
+    args: tuple[object, ...]
+    kwargs: dict[str, object]
+
+    def __init__(
+        self,
+        triton_kernel: JITFunction[object],
+        grid: object,
+        args: tuple[object, ...],
+        kwargs: dict[str, object],
+    ) -> None:
         super().__init__()
         self.kernel = triton_kernel
         self.grid = grid

--- a/helion/runtime/__init__.py
+++ b/helion/runtime/__init__.py
@@ -50,7 +50,7 @@ def default_launcher(
     *args: object,
     num_warps: int,
     num_stages: int,
-):
+) -> object:
     """Default launcher function that executes the kernel immediately."""
     return triton_kernel.run(
         *args, grid=grid, warmup=False, num_warps=num_warps, num_stages=num_stages

--- a/helion/runtime/config.py
+++ b/helion/runtime/config.py
@@ -183,7 +183,7 @@ class Config(Mapping[str, object]):
 
     @property
     def indexing(self) -> IndexingLiteral:
-        return self.config.get("indexing", "pointer")  # type: ignore
+        return self.config.get("indexing", "pointer")  # type: ignore[return-value]
 
 
 def _list_to_tuple(x: object) -> object:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,8 +54,8 @@ exclude = [".github/*"]
 
 [tool.ruff.lint]
 select = [
-    "A", "B", "C4", "COM", "D419", "E", "ERA001", "EXE", "F", "FA", "FLY", "FURB",
-    "G", "I", "ISC", "LOG", "NPY", "PERF", "PGH004", "PIE", "PLC0131", "PLC0132",
+    "A", "ANN", "B", "C4", "COM", "D419", "E", "ERA001", "EXE", "F", "FA", "FLY", "FURB",
+    "G", "I", "ISC", "LOG", "NPY", "PERF", "PGH", "PIE", "PLC0131", "PLC0132",
     "PLC0205", "PLC0208", "PLC2401", "PLC3002", "PLE", "PLR0133", "PLR0206",
     "PLR1722", "PLR1736", "PLW0129", "PLW0131", "PLW0133", "PLW0245", "PLW0406",
     "PLW0711", "PLW1501", "PLW1509", "PLW2101", "PLW3301", "PYI", "Q", "RET",
@@ -72,6 +72,9 @@ ignore = [
 extend-safe-fixes = ["TC", "UP045", "RUF013", "RSE102"]
 preview = true
 exclude = ["test/data/*", ".github/*"]
+
+[tool.ruff.lint.per-file-ignores]
+"test/*" = ["ANN"]
 
 [tool.ruff.lint.isort]
 extra-standard-library = ["typing_extensions"]


### PR DESCRIPTION
Stacked PRs (oldest at bottom):
 * #317
 * #316
 * __->__#315
 * #314
 * #313


--- --- ---

Enforce ANN/PGH lints

One thing we lost in the pyre => pyright switch is enforcing that
everything is typed (I had disabled ANN since the errors were rudundant
with pyre).