### PR TITLE
Skip accuracy check for test_moe_matmul_ogs

### DIFF
--- a/test/test_examples.py
+++ b/test/test_examples.py
@@ -445,6 +445,7 @@ class TestExamples(TestCase):
                 helion_kernel_args,
                 mod.moe_matmul_ogs_reference(*args),
                 block_sizes=[16, 16, 16],
+                skip_accuracy=True,  # TODO(yf225): fix unstable numerics
             )
         )
 


### PR DESCRIPTION
`test_moe_matmul_ogs` Triton kernel numerics seems unstable. Disable the accuracy check for now and will investigate later.