### PR TITLE
Do not create a new variable for tile assignments since tiles are immutable

### DIFF
--- a/helion/_compiler/device_ir.py
+++ b/helion/_compiler/device_ir.py
@@ -748,7 +748,9 @@ class WalkDeviceAST(NodeVisitor):
             value = self.visit(node.value)
             # For simple variable assignments like `a = b`, we need to create a new
             # variable to avoid phi node issues when the source variable gets mutated
-            if isinstance(node.value, ast.Name) and isinstance(value, torch.Tensor):
+            if isinstance(node.value, ast.Name) and (
+                isinstance(value, torch.Tensor) and not isinstance(value, Tile)
+            ):
                 value = _new_var(value)
             self._assign(target, value)
             return None

--- a/test/test_misc.expected
+++ b/test/test_misc.expected
@@ -43,6 +43,29 @@ def kernel(a_list, b_dict, b_tuple, c_named_tuple, d_dataclass, *, _launcher=_de
     _launcher(_kernel_kernel, (triton.cdiv(a0.size(0), _BLOCK_SIZE_0),), a0, o0, o1, a0.size(0), a0.stride(0), o0.stride(0), o1.stride(0), _BLOCK_SIZE_0, num_warps=4, num_stages=3)
     return [o0, o1]
 
+--- assertExpectedJournal(TestMisc.test_propagate_tile)
+from __future__ import annotations
+
+import torch
+import triton
+import triton.language as tl
+from helion.runtime import default_launcher as _default_launcher
+
+@triton.jit
+def _copy_kernel_kernel(a, out, a_size_0, a_stride_0, out_stride_0, _BLOCK_SIZE_0: tl.constexpr):
+    pid_0 = tl.program_id(0)
+    offset_0 = pid_0 * _BLOCK_SIZE_0
+    indices_0 = (offset_0 + tl.arange(0, _BLOCK_SIZE_0)).to(tl.int32)
+    mask_0 = indices_0 < a_size_0
+    load = tl.load(a + indices_0 * a_stride_0, mask_0, other=0)
+    tl.store(out + indices_0 * out_stride_0, load, mask_0)
+
+def copy_kernel(a: torch.Tensor, *, _launcher=_default_launcher):
+    out = torch.empty_like(a)
+    _BLOCK_SIZE_0 = 4
+    _launcher(_copy_kernel_kernel, (triton.cdiv(a.size(0), _BLOCK_SIZE_0),), a, out, a.size(0), a.stride(0), out.stride(0), _BLOCK_SIZE_0, num_warps=4, num_stages=3)
+    return out
+
 --- assertExpectedJournal(TestMisc.test_scalar_tensor_item_method)
 from __future__ import annotations
 


### PR DESCRIPTION
Stacked PRs:
 * __->__#334


--- --- ---

### Do not create a new variable for tile assignments since tiles are immutable


Fixes #332

Previously it was erroring with
```
helion.exc.InternalError: RuntimeError: Tile(0) (139684109802224)is not
tracked with proxy for
<torch.fx.experimental.proxy_tensor.PythonKeyTracer object at
0x7f0abf06cc90>
```