### PR TITLE
[RFC] Add @helion.autotune

### DIFF
--- a/helion/__init__.py
+++ b/helion/__init__.py
@@ -9,6 +9,7 @@ from . import language
 from . import runtime
 from .runtime import Config
 from .runtime import Kernel
+from .runtime import autotune
 from .runtime import kernel
 from .runtime import kernel as jit  # alias
 from .runtime.settings import Settings
@@ -18,6 +19,7 @@ __all__ = [
     "Config",
     "Kernel",
     "Settings",
+    "autotune",
     "cdiv",
     "exc",
     "jit",

--- a/helion/_compiler/host_function.py
+++ b/helion/_compiler/host_function.py
@@ -119,14 +119,14 @@ class HostFunction:
                 if isinstance(decorator, ast.Name):
                     return decorator.id
                 if isinstance(decorator, ast.Attribute):
-                    return get_decorator_name(decorator.value)
+                    return get_decorator_name(decorator.value) + "." + decorator.attr
                 if isinstance(decorator, ast.Call):
                     return get_decorator_name(decorator.func)
                 raise AssertionError(f"Unknown decorator: {decorator}")
 
             for idx, decorator in enumerate(root.decorator_list):
                 # TODO(oulgen): this can break if someone did `import helion as helion2`
-                if get_decorator_name(decorator) == "helion":
+                if get_decorator_name(decorator) == "helion.kernel":
                     if idx != len(root.decorator_list) - 1:
                         raise exc.DecoratorAfterHelionKernelDecorator
 

--- a/helion/autotuner/base_cache.py
+++ b/helion/autotuner/base_cache.py
@@ -17,7 +17,6 @@ from .._utils import counters
 
 if TYPE_CHECKING:
     from ..runtime.config import Config
-    from ..runtime.kernel import BoundKernel
     from .base_search import BaseSearch
 
 log: logging.Logger = logging.getLogger(__name__)
@@ -113,9 +112,9 @@ class AutotuneCacheBase(abc.ABC):
     provide implementations for get and put methods.
     """
 
-    def __init__(self, kernel: BoundKernel, autotuner: BaseSearch) -> None:
+    def __init__(self, autotuner: BaseSearch) -> None:
         self.autotuner = autotuner
-        self.kernel = kernel
+        self.kernel = self.autotuner.kernel
 
     @abc.abstractmethod
     def get(self) -> Config | None:

--- a/helion/autotuner/base_cache.py
+++ b/helion/autotuner/base_cache.py
@@ -8,7 +8,6 @@ import logging
 import os
 from typing import TYPE_CHECKING
 from typing import Hashable
-from typing import Sequence
 
 from torch._inductor.codecache import build_code_hash
 from torch._inductor.codecache import torch_key
@@ -114,12 +113,9 @@ class AutotuneCacheBase(abc.ABC):
     provide implementations for get and put methods.
     """
 
-    def __init__(
-        self, kernel: BoundKernel, args: Sequence[object], autotuner: BaseSearch
-    ) -> None:
+    def __init__(self, kernel: BoundKernel, autotuner: BaseSearch) -> None:
         self.autotuner = autotuner
         self.kernel = kernel
-        self.args = args
 
     @abc.abstractmethod
     def get(self) -> Config | None:

--- a/helion/autotuner/differential_evolution.py
+++ b/helion/autotuner/differential_evolution.py
@@ -11,7 +11,6 @@ from .base_search import population_statistics
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
-    from collections.abc import Sequence
 
     from ..runtime.config import Config
     from ..runtime.kernel import BoundKernel
@@ -25,13 +24,12 @@ class DifferentialEvolutionSearch(PopulationBasedSearch):
     def __init__(
         self,
         kernel: BoundKernel,
-        args: Sequence[object],
         population_size: int = 40,
         num_generations: int = 20,
         crossover_rate: float = 0.8,
         immediate_update: bool | None = None,
     ) -> None:
-        super().__init__(kernel, args)
+        super().__init__(kernel)
         if immediate_update is None:
             immediate_update = not kernel.settings.autotune_precompile
         self.population_size = population_size

--- a/helion/autotuner/finite_search.py
+++ b/helion/autotuner/finite_search.py
@@ -6,8 +6,6 @@ from .. import exc
 from .base_search import BaseSearch
 
 if TYPE_CHECKING:
-    from collections.abc import Sequence
-
     from ..runtime.config import Config
     from ..runtime.kernel import BoundKernel
 
@@ -22,10 +20,9 @@ class FiniteSearch(BaseSearch):
     def __init__(
         self,
         kernel: BoundKernel,
-        args: Sequence[object],
         configs: list[Config] | None = None,
     ) -> None:
-        super().__init__(kernel, args)
+        super().__init__(kernel)
         self.configs: list[Config] = [*(configs or ())]
         if len(self.configs) == 0 and self.kernel.configs:
             self.configs.extend(self.kernel.configs)

--- a/helion/autotuner/local_cache.py
+++ b/helion/autotuner/local_cache.py
@@ -7,7 +7,6 @@ import os
 from pathlib import Path
 import textwrap
 from typing import TYPE_CHECKING
-from typing import Sequence
 
 import torch
 from torch._inductor.runtime.cache_dir_utils import (
@@ -38,17 +37,15 @@ class LocalAutotuneCache(AutotuneCacheBase):
     PyTorch. Use StrictLocalAutotuneCache to consider these properties.
     """
 
-    def __init__(
-        self, kernel: BoundKernel, args: Sequence[object], autotuner: BaseSearch
-    ) -> None:
-        super().__init__(kernel, args, autotuner)
+    def __init__(self, kernel: BoundKernel, autotuner: BaseSearch) -> None:
+        super().__init__(kernel, autotuner)
         self.key = self._generate_key()
 
     def _generate_key(self) -> LooseAutotuneCacheKey:
         in_memory_cache_key = self.kernel.kernel._create_bound_kernel_cache_key(
             self.kernel,
-            tuple(self.args),
-            self.kernel.kernel.specialization_key(self.args),
+            tuple(self.kernel.args),
+            self.kernel.kernel.specialization_key(self.kernel.args),
         )
         kernel_source = textwrap.dedent(inspect.getsource(self.kernel.kernel.fn))
         kernel_source_hash = hashlib.sha256(kernel_source.encode("utf-8")).hexdigest()
@@ -56,7 +53,7 @@ class LocalAutotuneCache(AutotuneCacheBase):
         hardware = None
         runtime_name = None
 
-        for arg in self.args:
+        for arg in self.kernel.args:
             if isinstance(arg, torch.Tensor):
                 device_properties = torch.cuda.get_device_properties(arg.device)
                 if torch.version.cuda is not None:  # pyright: ignore[reportAttributeAccessIssue]

--- a/helion/autotuner/local_cache.py
+++ b/helion/autotuner/local_cache.py
@@ -19,7 +19,6 @@ from .base_cache import LooseAutotuneCacheKey
 from .base_cache import StrictAutotuneCacheKey
 
 if TYPE_CHECKING:
-    from ..runtime.kernel import BoundKernel
     from .base_search import BaseSearch
 
 log: logging.Logger = logging.getLogger(__name__)
@@ -37,8 +36,8 @@ class LocalAutotuneCache(AutotuneCacheBase):
     PyTorch. Use StrictLocalAutotuneCache to consider these properties.
     """
 
-    def __init__(self, kernel: BoundKernel, autotuner: BaseSearch) -> None:
-        super().__init__(kernel, autotuner)
+    def __init__(self, autotuner: BaseSearch) -> None:
+        super().__init__(autotuner)
         self.key = self._generate_key()
 
     def _generate_key(self) -> LooseAutotuneCacheKey:

--- a/helion/autotuner/random_search.py
+++ b/helion/autotuner/random_search.py
@@ -6,8 +6,6 @@ from .config_generation import ConfigGeneration
 from .finite_search import FiniteSearch
 
 if TYPE_CHECKING:
-    from collections.abc import Sequence
-
     from ..runtime.kernel import BoundKernel
 
 
@@ -23,18 +21,15 @@ class RandomSearch(FiniteSearch):
 
     Attributes:
         kernel (BoundKernel): The kernel to be tuned.
-        args (Sequence[object]): The arguments to be passed to the kernel.
         count (int): The number of random configurations to generate.
     """
 
     def __init__(
         self,
         kernel: BoundKernel,
-        args: Sequence[object],
         count: int = 1000,
     ) -> None:
         super().__init__(
             kernel,
-            args,
             configs=ConfigGeneration(kernel.config_spec).random_population(count),
         )

--- a/helion/runtime/__init__.py
+++ b/helion/runtime/__init__.py
@@ -7,6 +7,7 @@ import triton
 
 from .config import Config as Config
 from .kernel import Kernel as Kernel
+from .kernel import autotune as autotune
 from .kernel import kernel as kernel
 from .triton_helpers import triton_send_signal as triton_send_signal
 from .triton_helpers import triton_wait_multiple_signal as triton_wait_multiple_signal

--- a/helion/runtime/kernel.py
+++ b/helion/runtime/kernel.py
@@ -459,7 +459,6 @@ class BoundKernel(Generic[_R]):
             from ..autotuner import LocalAutotuneCache
 
             config = LocalAutotuneCache(
-                self,
                 DifferentialEvolutionSearch(
                     self,
                     **kwargs,  # pyright: ignore[reportArgumentType]

--- a/helion/runtime/settings.py
+++ b/helion/runtime/settings.py
@@ -62,6 +62,7 @@ class _Settings:
     )
     static_shapes: bool = False
     use_default_config: bool = os.environ.get("HELION_USE_DEFAULT_CONFIG", "0") == "1"
+    use_default_autotuner: bool = False
     autotune_log_level: int = logging.INFO
     autotune_compile_timeout: int = int(
         os.environ.get("HELION_AUTOTUNE_COMPILE_TIMEOUT", "60")
@@ -86,6 +87,7 @@ class Settings(_Settings):
         "dot_precision": "Precision for dot products, see `triton.language.dot`. Can be 'tf32', 'tf32x3', or 'ieee'.",
         "static_shapes": "If True, use static shapes for all tensors. This is a performance optimization.",
         "use_default_config": "For development only, skips all autotuning and uses the default config (which may be slow).",
+        "use_default_autotuner": "If no configs are provided, uses the default autotuner to tune the kernel.",
         "autotune_log_level": "Log level for autotuning using Python logging levels. Default is logging.INFO. Use 0 to disable all output.",
         "autotune_compile_timeout": "Timeout for Triton compilation in seconds used for autotuning. Default is 60 seconds.",
         "autotune_precompile": "If True, precompile the kernel before autotuning. Requires fork-safe environment.",

--- a/test/test_autotuner.py
+++ b/test/test_autotuner.py
@@ -127,7 +127,7 @@ class TestAutotuner(TestCase):
             torch.randn([512, 512], device=DEVICE),
         )
         bound_kernel = examples_matmul.bind(args)
-        best = RandomSearch(bound_kernel, args, 5).autotune()
+        best = RandomSearch(bound_kernel, 5).autotune()
         fn = bound_kernel.compile_config(best)
         torch.testing.assert_close(fn(*args), args[0] @ args[1], rtol=1e-2, atol=1e-1)
 
@@ -138,7 +138,7 @@ class TestAutotuner(TestCase):
         )
         bound_kernel = examples_matmul.bind(args)
         best = DifferentialEvolutionSearch(
-            bound_kernel, args, 5, num_generations=3
+            bound_kernel, 5, num_generations=3
         ).autotune()
         fn = bound_kernel.compile_config(best)
         torch.testing.assert_close(fn(*args), args[0] @ args[1], rtol=1e-2, atol=1e-1)

--- a/test/test_autotuner.py
+++ b/test/test_autotuner.py
@@ -159,6 +159,7 @@ class TestAutotuner(TestCase):
         torch.testing.assert_close(result, sum(args))
 
     def test_autotuner_disabled(self):
+        @helion.autotune
         @helion.kernel
         def add(a, b):
             out = torch.empty_like(a)

--- a/test/test_cache.py
+++ b/test/test_cache.py
@@ -29,9 +29,7 @@ class TestCache(TestCase):
         args_b = (b, b)
 
         bound_kernel = basic_kernels.add.bind(args_a)
-        config = StrictLocalAutotuneCache(
-            bound_kernel, BasicSearch(bound_kernel)
-        ).autotune()
+        config = StrictLocalAutotuneCache(BasicSearch(bound_kernel)).autotune()
         bound_kernel.set_config(config)
         result = bound_kernel(*args_a)
         torch.testing.assert_close(result, a + a)
@@ -43,9 +41,7 @@ class TestCache(TestCase):
         basic_kernels.add.reset()
 
         bound_kernel = basic_kernels.add.bind(args_a)
-        config = StrictLocalAutotuneCache(
-            bound_kernel, BasicSearch(bound_kernel)
-        ).autotune()
+        config = StrictLocalAutotuneCache(BasicSearch(bound_kernel)).autotune()
         bound_kernel.set_config(config)
         result = bound_kernel(*args_a)
         torch.testing.assert_close(result, a + a)
@@ -57,9 +53,7 @@ class TestCache(TestCase):
         basic_kernels.add.reset()
 
         bound_kernel = basic_kernels.add.bind(args_b)
-        config = StrictLocalAutotuneCache(
-            bound_kernel, BasicSearch(bound_kernel)
-        ).autotune()
+        config = StrictLocalAutotuneCache(BasicSearch(bound_kernel)).autotune()
         bound_kernel.set_config(config)
         result = bound_kernel(*args_b)
         torch.testing.assert_close(result, b + b)

--- a/test/test_cache.py
+++ b/test/test_cache.py
@@ -28,10 +28,9 @@ class TestCache(TestCase):
         b = torch.randn(16, device=DEVICE, dtype=torch.float16)
         args_b = (b, b)
 
-        # TODO(oulgen): Using a custom autotuner is very verbose, requires passing args 3 times etc
         bound_kernel = basic_kernels.add.bind(args_a)
         config = StrictLocalAutotuneCache(
-            bound_kernel, args_a, BasicSearch(bound_kernel, args_a)
+            bound_kernel, BasicSearch(bound_kernel)
         ).autotune()
         bound_kernel.set_config(config)
         result = bound_kernel(*args_a)
@@ -45,7 +44,7 @@ class TestCache(TestCase):
 
         bound_kernel = basic_kernels.add.bind(args_a)
         config = StrictLocalAutotuneCache(
-            bound_kernel, args_a, BasicSearch(bound_kernel, args_a)
+            bound_kernel, BasicSearch(bound_kernel)
         ).autotune()
         bound_kernel.set_config(config)
         result = bound_kernel(*args_a)
@@ -59,7 +58,7 @@ class TestCache(TestCase):
 
         bound_kernel = basic_kernels.add.bind(args_b)
         config = StrictLocalAutotuneCache(
-            bound_kernel, args_b, BasicSearch(bound_kernel, args_b)
+            bound_kernel, BasicSearch(bound_kernel)
         ).autotune()
         bound_kernel.set_config(config)
         result = bound_kernel(*args_b)


### PR DESCRIPTION
Stacked PRs:
 * __->__#389
 * #388
 * #387


--- --- ---

### [RFC] Add @helion.autotune


Running `python examples/add.py` will now give
```
Using default config for kernel: Config(block_sizes=[32, 32], loop_orders=[[0, 1]], flatten_loops=[False], l2_groupings=[1], range_unroll_factors=[0], range_warp_specializes=[], range_num_stages=[0], range_multi_buffers=[None], range_flattens=[N
one], num_warps=4, num_stages=3, indexing='pointer', pid_type='flat'), please use @helion.autotune for better performance.
```
