### PR TITLE
Temporarily move triton_key import to inner function to unblock older torch versions

### DIFF
--- a/helion/autotuner/base_cache.py
+++ b/helion/autotuner/base_cache.py
@@ -11,7 +11,6 @@ from typing import Hashable
 
 from torch._inductor.codecache import build_code_hash
 from torch._inductor.codecache import torch_key
-from torch._inductor.runtime.triton_compat import triton_key
 
 from .._utils import counters
 
@@ -39,6 +38,8 @@ def torch_key_wrapper() -> str:
 
 @functools.cache
 def triton_key_wrapper() -> str:
+    from torch._inductor.runtime.triton_compat import triton_key
+
     return triton_key()
 
 


### PR DESCRIPTION
Stacked PRs:
 * __->__#395


--- --- ---

### Temporarily move triton_key import to inner function to unblock older torch versions


Fixes #392