### PR TITLE
[Benchmark] Fix arg parsing issue in tritonbench integration

### DIFF
--- a/benchmarks/run.py
+++ b/benchmarks/run.py
@@ -477,10 +477,15 @@ def run_kernel_variants(
 
 def main() -> None:
     # Parse command line arguments
-    parser = argparse.ArgumentParser(description="Run Helion kernels with tritonbench")
+    parser = argparse.ArgumentParser(
+        description="Run Helion kernels with tritonbench",
+        allow_abbrev=False,  # Disable prefix matching to prevent --k from matching --kernel
+    )
     parser.add_argument(
         "--kernel",
+        "--op",
         type=str,
+        dest="kernel",
         help="Name(s) of the Helion kernel module(s) to run. Can be a single kernel or comma-separated list (e.g., vector_add or vector_add,rms_norm). If not specified, runs all kernels.",
     )
     parser.add_argument(


### PR DESCRIPTION
- `--k` is by default an abbreviation of `--kernel`, preventing `--kernel gemm --k 4096` from working. This PR fixes it.
- Add `--op` that aliases `--kernel`, for better tritonbench arg name matching.